### PR TITLE
Update dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.4.3",
+      "version": "5.5.11",
       "commands": [
         "reportgenerator"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -38,7 +38,7 @@
       "rollForward": false
     },
     "dotnet-outdated-tool": {
-      "version": "4.6.7",
+      "version": "4.8.1",
       "commands": [
         "dotnet-outdated"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "husky": {
-      "version": "0.7.2",
+      "version": "0.9.1",
       "commands": [
         "husky"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,9 +24,9 @@
       "rollForward": false
     },
     "csharpier": {
-      "version": "0.30.6",
+      "version": "1.3.0",
       "commands": [
-        "dotnet-csharpier"
+        "csharpier"
       ],
       "rollForward": false
     },

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "coverlet.console": {
-      "version": "6.0.2",
+      "version": "10.0.1",
       "commands": [
         "coverlet"
       ],

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -10,7 +10,7 @@
       {
          "name": "CSharpier",
          "command": "dotnet",
-         "args": [ "csharpier", "${staged}" ],
+         "args": [ "csharpier", "format", "${staged}" ],
          "include": ["**/*.cs"]
       }
    ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,13 @@
 <Project>
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <MicrosoftPackageVersion>10.0.10</MicrosoftPackageVersion>
-        <Nullable>enable</Nullable>
-        <Version>0.0.0</Version>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <MicrosoftPackageVersion>10.0.10</MicrosoftPackageVersion>
+    <Nullable>enable</Nullable>
+    <Version>0.0.0</Version>
+  </PropertyGroup>
 
-    <ItemGroup Condition="'$(MSBuildProjectName)' == 'Haus.Web.Host' OR '$(MSBuildProjectName)' == 'Haus.Zigbee.Host'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'Haus.Web.Host' OR '$(MSBuildProjectName)' == 'Haus.Zigbee.Host'">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Api.Client/Haus.Api.Client.csproj
+++ b/src/Haus.Api.Client/Haus.Api.Client.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Core.Models/Haus.Core.Models.csproj
+++ b/src/Haus.Core.Models/Haus.Core.Models.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <PackageReference Include="Humanizer" Version="3.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Humanizer" Version="3.0.10" />
+    <PackageReference
+      Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions"
+      Version="$(MicrosoftPackageVersion)"
+    />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Core/Haus.Core.csproj
+++ b/src/Haus.Core/Haus.Core.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj" />
+    <ProjectReference Include="..\Haus.Cqrs\Haus.Cqrs.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj"/>
-        <ProjectReference Include="..\Haus.Cqrs\Haus.Cqrs.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="System.Reactive" Version="7.0.0"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference
+      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+      Version="$(MicrosoftPackageVersion)"
+    />
+    <PackageReference Include="System.Reactive" Version="7.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Core/Rooms/Repositories/RoomCommandRepository.cs
+++ b/src/Haus.Core/Rooms/Repositories/RoomCommandRepository.cs
@@ -24,7 +24,7 @@ public class RoomCommandRepository(HausDbContext context) : IRoomCommandReposito
             .GetAll<DeviceEntity>()
             .Where(d => d.ExternalId == externalId)
             .Include(d => d.Room)
-            .ThenInclude(r => r!.Devices)
+                .ThenInclude(r => r!.Devices)
             .Select(d => d.Room)
             .SingleOrDefaultAsync(cancellationToken);
     }

--- a/src/Haus.Cqrs/Haus.Cqrs.csproj
+++ b/src/Haus.Cqrs/Haus.Cqrs.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference
+      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+      Version="$(MicrosoftPackageVersion)"
+    />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Hosting/Haus.Hosting.csproj
+++ b/src/Haus.Hosting/Haus.Hosting.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference
+      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+      Version="$(MicrosoftPackageVersion)"
+    />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Mqtt.Client/Haus.Mqtt.Client.csproj
+++ b/src/Haus.Mqtt.Client/Haus.Mqtt.Client.csproj
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
+    <PackageReference Include="Polly" Version="8.7.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207"/>
-        <PackageReference Include="Polly" Version="8.7.0"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Site.Host/Haus.Site.Host.csproj
+++ b/src/Haus.Site.Host/Haus.Site.Host.csproj
@@ -2,7 +2,7 @@
   
   <ItemGroup>
     <PackageReference Include="Humanizer" Version="3.0.10" />
-    <PackageReference Include="MudBlazor" Version="9.7.0" />
+    <PackageReference Include="MudBlazor" Version="9.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />

--- a/src/Haus.Site.Host/Haus.Site.Host.csproj
+++ b/src/Haus.Site.Host/Haus.Site.Host.csproj
@@ -1,21 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-  
   <ItemGroup>
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <PackageReference Include="MudBlazor" Version="9.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference
+      Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication"
+      Version="$(MicrosoftPackageVersion)"
+    />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftPackageVersion)" PrivateAssets="all" />
+    <PackageReference
+      Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer"
+      Version="$(MicrosoftPackageVersion)"
+      PrivateAssets="all"
+    />
     <PackageReference Include="System.Reactive" Version="7.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Haus.Api.Client\Haus.Api.Client.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Update="wwwroot\appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -24,9 +30,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <_ContentIncludedByDefault Remove="Pages\Index.razor" />
   </ItemGroup>
-
 </Project>

--- a/src/Haus.Site.Host/Shared/Formatting/DateTimeExtensions.cs
+++ b/src/Haus.Site.Host/Shared/Formatting/DateTimeExtensions.cs
@@ -5,7 +5,7 @@ namespace Haus.Site.Host.Shared.Formatting;
 public static class DateTimeExtensions
 {
     private const string DateFormat = "yyyy-MM-dd HH:mm:ss";
-    
+
     public static string FormatTimestamp(this string timestamp)
     {
         return DateTimeOffset.TryParse(timestamp, out var date) ? date.FormatTimestamp() : timestamp;

--- a/src/Haus.Udp.Client/Haus.Udp.Client.csproj
+++ b/src/Haus.Udp.Client/Haus.Udp.Client.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Utilities/Haus.Utilities.csproj
+++ b/src/Haus.Utilities/Haus.Utilities.csproj
@@ -1,19 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Humanizer.Core" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-        <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Cqrs\Haus.Cqrs.csproj" />
-        <ProjectReference Include="..\Haus.Hosting\Haus.Hosting.csproj" />
-        <ProjectReference Include="..\Haus.Zigbee.Host\Haus.Zigbee.Host.csproj" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Cqrs\Haus.Cqrs.csproj" />
+    <ProjectReference Include="..\Haus.Hosting\Haus.Hosting.csproj" />
+    <ProjectReference Include="..\Haus.Zigbee.Host\Haus.Zigbee.Host.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Web.Host/Haus.Web.Host.csproj
+++ b/src/Haus.Web.Host/Haus.Web.Host.csproj
@@ -1,29 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftPackageVersion)">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Octokit" Version="14.0.0"/>
-        <!-- Override transitive SQLitePCLRaw pulled in by Microsoft.EntityFrameworkCore.Sqlite: 2.1.11 bundles a SQLite
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftPackageVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference
+      Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"
+      Version="$(MicrosoftPackageVersion)"
+    />
+    <PackageReference Include="Octokit" Version="14.0.0" />
+    <!-- Override transitive SQLitePCLRaw pulled in by Microsoft.EntityFrameworkCore.Sqlite: 2.1.11 bundles a SQLite
              build vulnerable to CVE-2025-6965 (GHSA-2m69-gcr7-jv3q). No patched 2.1.x SQLitePCLRaw exists except 2.1.12. -->
-        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12"/>
-    </ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Core\Haus.Core.csproj"/>
-        <ProjectReference Include="..\Haus.Hosting\Haus.Hosting.csproj"/>
-        <ProjectReference Include="..\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Core\Haus.Core.csproj" />
+    <ProjectReference Include="..\Haus.Hosting\Haus.Hosting.csproj" />
+    <ProjectReference Include="..\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Haus.Web.Host/Haus.Web.Host.csproj
+++ b/src/Haus.Web.Host/Haus.Web.Host.csproj
@@ -15,6 +15,9 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftPackageVersion)"/>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)"/>
         <PackageReference Include="Octokit" Version="14.0.0"/>
+        <!-- Override transitive SQLitePCLRaw pulled in by Microsoft.EntityFrameworkCore.Sqlite: 2.1.11 bundles a SQLite
+             build vulnerable to CVE-2025-6965 (GHSA-2m69-gcr7-jv3q). No patched 2.1.x SQLitePCLRaw exists except 2.1.12. -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Haus.Zigbee.Host/Haus.Zigbee.Host.csproj
+++ b/src/Haus.Zigbee.Host/Haus.Zigbee.Host.csproj
@@ -1,30 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj" />
+    <ProjectReference Include="..\Haus.Hosting\Haus.Hosting.csproj" />
+    <ProjectReference Include="..\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Haus.Core.Models\Haus.Core.Models.csproj"/>
-        <ProjectReference Include="..\Haus.Hosting\Haus.Hosting.csproj"/>
-        <ProjectReference Include="..\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+    <Content Remove="Zigbee2Mqtt\Resolvers\DefaultDeviceTypeOptions.json" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <Content Remove="Zigbee2Mqtt\Resolvers\DefaultDeviceTypeOptions.json"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <EmbeddedResource Include="Zigbee2Mqtt\Mappers\ToHaus\Resolvers\DefaultDeviceTypeOptions.json">
-            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        </EmbeddedResource>
-    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Zigbee2Mqtt\Mappers\ToHaus\Resolvers\DefaultDeviceTypeOptions.json">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Haus.Zigbee.Host/Zigbee2Mqtt/Mappers/ToHaus/DevicesMapper.cs
+++ b/src/Haus.Zigbee.Host/Zigbee2Mqtt/Mappers/ToHaus/DevicesMapper.cs
@@ -33,7 +33,8 @@ public class DevicesMapper(
                 {
                     Topic = hausOptions.GetEventsTopic(),
                     PayloadSegment = HausJsonSerializer.SerializeToBytes(CreateDeviceDiscoveredEvent(item)),
-                }) ?? [];
+                })
+            ?? [];
     }
 
     private HausEvent<DeviceDiscoveredEvent> CreateDeviceDiscoveredEvent(JObject jToken)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,24 +1,24 @@
 <Project>
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-    <PropertyGroup Condition="'$(MSBuildProjectName)' != 'Haus.Testing.Support' AND '$(MSBuildProjectName)' != 'Haus.Acceptance.Tests'">
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildProjectName)' != 'Haus.Testing.Support' AND '$(MSBuildProjectName)' != 'Haus.Acceptance.Tests'">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup Condition="'$(MSBuildProjectName)' != 'Haus.Testing.Support' AND '$(MSBuildProjectName)' != 'Haus.Acceptance.Tests'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
-        <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Haus.Testing.Support' AND '$(MSBuildProjectName)' != 'Haus.Acceptance.Tests'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
+++ b/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
@@ -1,25 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    
-    <ItemGroup>
-        <PackageReference Include="NUnit" Version="4.6.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
-        <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.61.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    
-    <ItemGroup>
-      <Folder Include="playwright\.auth\" />
-    </ItemGroup>
-    
-    <ItemGroup>
-      <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
-    </ItemGroup>
-    
-    <Target Name="InstallBrowsers" AfterTargets="Build">
-        <Exec Command="pwsh bin/$(Configuration)/$(TargetFramework)/playwright.ps1 install --with-deps" />
-    </Target>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.61.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="playwright\.auth\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
+
+  <Target Name="InstallBrowsers" AfterTargets="Build">
+    <Exec Command="pwsh bin/$(Configuration)/$(TargetFramework)/playwright.ps1 install --with-deps" />
+  </Target>
 </Project>

--- a/tests/Haus.Core.Models.Tests/Haus.Core.Models.Tests.csproj
+++ b/tests/Haus.Core.Models.Tests/Haus.Core.Models.Tests.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Core.Models\Haus.Core.Models.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Core.Models\Haus.Core.Models.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Core.Models.Tests/Health/HausHealthReportModelTests.cs
+++ b/tests/Haus.Core.Models.Tests/Health/HausHealthReportModelTests.cs
@@ -25,9 +25,9 @@ public class HausHealthReportModelTests
     [Fact]
     public void WhenChecksAreAppendedWithUnhealthyStatusThenReportStatusIsUnhealthy()
     {
-        var report = new HausHealthReportModel(HealthStatus.Healthy, 0, []).AppendChecks(
-            [new HausHealthCheckModel("one", HealthStatus.Unhealthy, 1)]
-        );
+        var report = new HausHealthReportModel(HealthStatus.Healthy, 0, []).AppendChecks([
+            new HausHealthCheckModel("one", HealthStatus.Unhealthy, 1),
+        ]);
 
         Assert.Equal(HealthStatus.Unhealthy, report.Status);
     }
@@ -35,9 +35,9 @@ public class HausHealthReportModelTests
     [Fact]
     public void WhenChecksAreAppendedWithDegradedStatusThenReportIsDegraded()
     {
-        var report = new HausHealthReportModel(HealthStatus.Healthy, 0, []).AppendChecks(
-            [new HausHealthCheckModel("one", HealthStatus.Degraded, 1)]
-        );
+        var report = new HausHealthReportModel(HealthStatus.Healthy, 0, []).AppendChecks([
+            new HausHealthCheckModel("one", HealthStatus.Degraded, 1),
+        ]);
 
         Assert.Equal(HealthStatus.Degraded, report.Status);
     }

--- a/tests/Haus.Core.Tests/Haus.Core.Tests.csproj
+++ b/tests/Haus.Core.Tests/Haus.Core.Tests.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Core\Haus.Core.csproj"/>
-        <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Core\Haus.Core.csproj" />
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Core.Tests/Haus.Core.Tests.csproj
+++ b/tests/Haus.Core.Tests/Haus.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Haus.Cqrs.Tests/Haus.Cqrs.Tests.csproj
+++ b/tests/Haus.Cqrs.Tests/Haus.Cqrs.Tests.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftPackageVersion)"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Cqrs\Haus.Cqrs.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Cqrs\Haus.Cqrs.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Mqtt.Client.Tests/Haus.Mqtt.Client.Tests.csproj
+++ b/tests/Haus.Mqtt.Client.Tests/Haus.Mqtt.Client.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj"/>
-        <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj" />
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Site.Host.Tests/Devices/Discovery/DeviceDiscoveryViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Devices/Discovery/DeviceDiscoveryViewTests.cs
@@ -67,20 +67,18 @@ public class DeviceDiscoveryViewTests : HausSiteTestContext
         await HausApiHandler.SetupGetAsJson(DevicesUrl, new ListResult<DeviceModel>());
         await HausApiHandler.SetupGetAsJson(
             RoomsUrl,
-            new ListResult<RoomModel>(
-                [
-                    HausModelFactory.RoomModel() with
-                    {
-                        Name = "Basement",
-                        Id = 4,
-                    },
-                    HausModelFactory.RoomModel() with
-                    {
-                        Name = "Master Bedroom",
-                        Id = 3,
-                    },
-                ]
-            )
+            new ListResult<RoomModel>([
+                HausModelFactory.RoomModel() with
+                {
+                    Name = "Basement",
+                    Id = 4,
+                },
+                HausModelFactory.RoomModel() with
+                {
+                    Name = "Master Bedroom",
+                    Id = 3,
+                },
+            ])
         );
 
         var page = Context.Render<DeviceDiscoveryView>();
@@ -100,26 +98,24 @@ public class DeviceDiscoveryViewTests : HausSiteTestContext
         );
         await HausApiHandler.SetupGetAsJson(
             DevicesUrl,
-            new ListResult<DeviceModel>(
-                [
-                    HausModelFactory.DeviceModel() with
-                    {
-                        RoomId = 6,
-                    },
-                    HausModelFactory.DeviceModel() with
-                    {
-                        RoomId = null,
-                    },
-                    HausModelFactory.DeviceModel() with
-                    {
-                        RoomId = null,
-                    },
-                    HausModelFactory.DeviceModel() with
-                    {
-                        RoomId = 6,
-                    },
-                ]
-            )
+            new ListResult<DeviceModel>([
+                HausModelFactory.DeviceModel() with
+                {
+                    RoomId = 6,
+                },
+                HausModelFactory.DeviceModel() with
+                {
+                    RoomId = null,
+                },
+                HausModelFactory.DeviceModel() with
+                {
+                    RoomId = null,
+                },
+                HausModelFactory.DeviceModel() with
+                {
+                    RoomId = 6,
+                },
+            ])
         );
 
         var page = Context.Render<DeviceDiscoveryView>();

--- a/tests/Haus.Site.Host.Tests/Devices/List/DevicesListViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Devices/List/DevicesListViewTests.cs
@@ -32,9 +32,11 @@ public class DevicesListViewTests : HausSiteTestContext
     {
         await HausApiHandler.SetupGetAsJson(
             DevicesUrl,
-            new ListResult<DeviceModel>(
-                [HausModelFactory.DeviceModel(), HausModelFactory.DeviceModel(), HausModelFactory.DeviceModel()]
-            )
+            new ListResult<DeviceModel>([
+                HausModelFactory.DeviceModel(),
+                HausModelFactory.DeviceModel(),
+                HausModelFactory.DeviceModel(),
+            ])
         );
 
         var page = RenderView<DevicesListView>();
@@ -50,9 +52,13 @@ public class DevicesListViewTests : HausSiteTestContext
     {
         await HausApiHandler.SetupGetAsJson(
             DevicesUrl,
-            new ListResult<DeviceModel>(
-                [HausModelFactory.DeviceModel() with { DeviceType = DeviceType.MotionSensor, Name = "Motions" }]
-            )
+            new ListResult<DeviceModel>([
+                HausModelFactory.DeviceModel() with
+                {
+                    DeviceType = DeviceType.MotionSensor,
+                    Name = "Motions",
+                },
+            ])
         );
 
         var page = RenderView<DevicesListView>();
@@ -70,9 +76,14 @@ public class DevicesListViewTests : HausSiteTestContext
     {
         await HausApiHandler.SetupGetAsJson(
             DevicesUrl,
-            new ListResult<DeviceModel>(
-                [HausModelFactory.DeviceModel() with { Id = 5, DeviceType = DeviceType.MotionSensor, Name = "Motions" }]
-            )
+            new ListResult<DeviceModel>([
+                HausModelFactory.DeviceModel() with
+                {
+                    Id = 5,
+                    DeviceType = DeviceType.MotionSensor,
+                    Name = "Motions",
+                },
+            ])
         );
 
         var page = RenderView<DevicesListView>();

--- a/tests/Haus.Site.Host.Tests/Haus.Site.Host.Tests.csproj
+++ b/tests/Haus.Site.Host.Tests/Haus.Site.Host.Tests.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
-	
-	<ItemGroup>
-		<PackageReference Include="bunit" Version="2.9.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="2.9.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\..\src\Haus.Site.Host\Haus.Site.Host.csproj" />
-	  <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Site.Host\Haus.Site.Host.csproj" />
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Site.Host.Tests/Haus.Site.Host.Tests.csproj
+++ b/tests/Haus.Site.Host.Tests/Haus.Site.Host.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 	
 	<ItemGroup>
-		<PackageReference Include="bunit" Version="2.7.2" />
+		<PackageReference Include="bunit" Version="2.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Haus.Site.Host.Tests/Health/Logs/LogsViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Health/Logs/LogsViewTests.cs
@@ -34,9 +34,11 @@ public class LogsViewTests : HausSiteTestContext
     {
         await HausApiHandler.SetupGetAsJson(
             "/api/logs",
-            new ListResult<LogEntryModel>(
-                [HausModelFactory.LogEntryModel(), HausModelFactory.LogEntryModel(), HausModelFactory.LogEntryModel()]
-            )
+            new ListResult<LogEntryModel>([
+                HausModelFactory.LogEntryModel(),
+                HausModelFactory.LogEntryModel(),
+                HausModelFactory.LogEntryModel(),
+            ])
         );
 
         var view = RenderView<LogsView>();

--- a/tests/Haus.Site.Host.Tests/Rooms/List/RoomsListViewTest.cs
+++ b/tests/Haus.Site.Host.Tests/Rooms/List/RoomsListViewTest.cs
@@ -31,9 +31,11 @@ public class RoomsListViewTest : HausSiteTestContext
     {
         await HausApiHandler.SetupGetAsJson(
             RoomsUrl,
-            new ListResult<RoomModel>(
-                [HausModelFactory.RoomModel(), HausModelFactory.RoomModel(), HausModelFactory.RoomModel()]
-            )
+            new ListResult<RoomModel>([
+                HausModelFactory.RoomModel(),
+                HausModelFactory.RoomModel(),
+                HausModelFactory.RoomModel(),
+            ])
         );
 
         var page = RenderView<RoomsListView>();

--- a/tests/Haus.Testing.Support/Haus.Testing.Support.csproj
+++ b/tests/Haus.Testing.Support/Haus.Testing.Support.csproj
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Core\Haus.Core.csproj" />
+    <ProjectReference Include="..\..\src\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Core\Haus.Core.csproj"/>
-        <ProjectReference Include="..\..\src\Haus.Mqtt.Client\Haus.Mqtt.Client.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Polly" Version="8.7.0"/>
-        <PackageReference Include="Bogus" Version="35.6.5" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Polly" Version="8.7.0" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Udp.Client.Tests/Haus.Udp.Client.Tests.csproj
+++ b/tests/Haus.Udp.Client.Tests/Haus.Udp.Client.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Udp.Client\Haus.Udp.Client.csproj"/>
-        <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Udp.Client\Haus.Udp.Client.csproj" />
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Utilities.Tests/Haus.Utilities.Tests.csproj
+++ b/tests/Haus.Utilities.Tests/Haus.Utilities.Tests.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Utilities\Haus.Utilities.csproj" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Utilities\Haus.Utilities.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Web.Host.Tests/Haus.Web.Host.Tests.csproj
+++ b/tests/Haus.Web.Host.Tests/Haus.Web.Host.Tests.csproj
@@ -1,16 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftPackageVersion)"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
-        <PackageReference Include="Polly.Extensions.Http" Version="3.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Api.Client\Haus.Api.Client.csproj"/>
-        <ProjectReference Include="..\..\src\Haus.Web.Host\Haus.Web.Host.csproj"/>
-        <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Api.Client\Haus.Api.Client.csproj" />
+    <ProjectReference Include="..\..\src\Haus.Web.Host\Haus.Web.Host.csproj" />
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Haus.Zigbee.Host.Tests/Haus.Zigbee.Host.Tests.csproj
+++ b/tests/Haus.Zigbee.Host.Tests/Haus.Zigbee.Host.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Haus.Zigbee.Host\Haus.Zigbee.Host.csproj"/>
-        <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Haus.Zigbee.Host\Haus.Zigbee.Host.csproj" />
+    <ProjectReference Include="..\Haus.Testing.Support\Haus.Testing.Support.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Routine dependency maintenance per the dependency-maintenance discipline: one logical update per commit, changelog reviewed for each, `dotnet build` + `make test-unit` green after every commit.

### Security patches
| Dependency | Old | New | Why |
|---|---|---|---|
| `SQLitePCLRaw.bundle_e_sqlite3` (transitive, pinned via explicit override in `Haus.Web.Host.csproj`) | 2.1.11 | 2.1.12 | Closes CVE-2025-6965 / GHSA-2m69-gcr7-jv3q (high, SQLite memory corruption). No EFCore.Sqlite release yet picks this up automatically; pinned the transitive package directly to the minimal patched version rather than jumping to the renumbered 3.x line. |
| `bunit` (Haus.Site.Host.Tests) | 2.7.2 | 2.9.0 | Also closes GHSA-pgww-w46g-26qg (AngleSharp mXSS, moderate) — bunit 2.9.0 requires AngleSharp 1.7.0, well past the 1.5.0 fix. |

### NuGet packages
| Dependency | Old | New |
|---|---|---|
| `Newtonsoft.Json` (Haus.Core.Tests) | 13.0.3 | 13.0.4 |
| `MudBlazor` (Haus.Site.Host) | 9.7.0 | 9.8.0 |

MudBlazor 9.8.0 documents 5 breaking changes (input adornment classes, MudTable `TableAttributes`, mini-drawer mobile behavior, MudSwitch label class, MudNavLink attribute forwarding) — reviewed against this codebase's usage and none apply (no `Mini` drawer variant, no custom classes on switch labels/input adornments, no `MudNavLink`).

### Local dotnet tools (`.config/dotnet-tools.json`)
| Tool | Old | New |
|---|---|---|
| `dotnet-reportgenerator-globaltool` | 5.4.3 | 5.5.11 |
| `dotnet-outdated-tool` | 4.6.7 | 4.8.1 |
| `husky` | 0.7.2 | 0.9.1 |
| `coverlet.console` | 6.0.2 | 10.0.1 |
| `csharpier` | 0.30.6 | 1.3.0 |
| `dotnet-ef` | 10.0.10 | — already latest, no change |

**csharpier 1.3.0** required an adaptation: 1.x needs the explicit `format` subcommand (`dotnet csharpier format <path>` instead of the old bare `dotnet csharpier <path>`), and the local-tool command name changed from `dotnet-csharpier` to `csharpier`. Updated `.husky/task-runner.json` and `.config/dotnet-tools.json` accordingly (one commit), then applied a separate mechanical, behavior-preserving reformat commit for the new engine's rules (collection-expression/`ThenInclude` indentation in a handful of `.cs` files, plus a new custom XML formatter now covering `.csproj`/`.props` files that 0.30.6 didn't touch at all — that XML formatting isn't enforced by the pre-commit hook, which is scoped to `**/*.cs`, but keeping it in sync avoids drift).

### Skipped
- **husky 0.8.0–0.9.1 bisection scare, resolved**: a standalone `dotnet husky run` (outside of an actual git hook) fails in this linked-worktree checkout with "Could not find Husky path" starting at 0.8.0. Verified this is *not* a real regression for the actual use case — the pre-commit hook itself (invoked by `git commit`, which sets up different git context than a bare CLI call) runs correctly under 0.9.1, confirmed via a real test commit. Bumped as planned.
- **Further SQLitePCLRaw bump (2.1.12 → 3.0.5)**: not required — 2.1.12 already closes the CVE. The 3.x line is a versioning-scheme renumbering by upstream, not needed here, and left alone to keep the security-fix diff minimal.

### Gates run per commit
- `dotnet build`
- `dotnet list package --vulnerable` (for the two security commits)
- `make test-unit` (full suite green after every commit)
- `dotnet csharpier check .` (clean after the csharpier commits)

### Known environment limitation (not caused by this PR)
In the sandbox this branch was developed in, `dotnet build` for the whole solution and `make test-acceptance` cannot fully complete: `Haus.Acceptance.Tests`' post-build Playwright browser install (`pwsh ... playwright.ps1 install --with-deps`) needs root/apt access that isn't available non-interactively there, and `make publish`'s packaging step needs `zip`, which also isn't installed. Both are pre-existing (reproduced identically against `main`) and unrelated to any dependency bumped here — all other projects compile cleanly, and `make test-unit` is fully green throughout. Recommend letting CI (which has these tools) run `make test-acceptance` before merge.

## Test plan
- [x] `dotnet build` succeeds for every project except the pre-existing, unrelated `Haus.Acceptance.Tests` Playwright-install step (reproduced on `main`)
- [x] `make test-unit` green after every commit
- [x] `dotnet list package --vulnerable` clean (both prior CVEs closed)
- [x] `dotnet csharpier check .` clean
- [x] `make test-acceptance` — not runnable in this sandbox (missing `zip`/root); should be verified in CI