### PR TITLE
Update dependencies (Aug 2026)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "dotnet-ef": {
-      "version": "10.0.10",
+      "version": "10.0.11",
       "commands": [
         "dotnet-ef"
       ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <MicrosoftPackageVersion>10.0.10</MicrosoftPackageVersion>
+    <MicrosoftPackageVersion>10.0.11</MicrosoftPackageVersion>
     <Nullable>enable</Nullable>
     <Version>0.0.0</Version>
   </PropertyGroup>

--- a/src/Haus.Web.Host/Haus.Web.Host.csproj
+++ b/src/Haus.Web.Host/Haus.Web.Host.csproj
@@ -17,9 +17,11 @@
       Version="$(MicrosoftPackageVersion)"
     />
     <PackageReference Include="Octokit" Version="14.0.0" />
-    <!-- Override transitive SQLitePCLRaw pulled in by Microsoft.EntityFrameworkCore.Sqlite: 2.1.11 bundles a SQLite
-             build vulnerable to CVE-2025-6965 (GHSA-2m69-gcr7-jv3q). No patched 2.1.x SQLitePCLRaw exists except 2.1.12. -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
+    <!-- Explicit override of the transitive SQLitePCLRaw pulled in by Microsoft.EntityFrameworkCore.Sqlite, kept
+             ahead of EFCore's own dependency so the bundled SQLite build stays current independent of EFCore's release
+             cadence. Originally pinned to 2.1.12 to close CVE-2025-6965 (GHSA-2m69-gcr7-jv3q); EFCore.Sqlite 10.0.11
+             now resolves 2.1.12 itself. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
+++ b/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
@@ -3,7 +3,7 @@
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.61.0" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.62.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
## Summary

Routine dependency maintenance since PR #20 (merged, tip `7e27dfe`). Found 4 outdated units — one security-relevant, three routine. Each is its own commit for bisectability.

| Package / tool | Old -> New | Why | Type |
|---|---|---|---|
| `MicrosoftPackageVersion` (EFCore, AspNetCore.*, Extensions.* — all pinned to one property in `Directory.Build.props`) | 10.0.10 -> 10.0.11 | **Security.** August 2026 .NET servicing release, closes 10 CVEs incl. 2 RCEs (CVE-2026-70354, CVE-2026-62897) and several EoP/info-disclosure issues. No breaking changes documented. | Security |
| `SQLitePCLRaw.bundle_e_sqlite3` (explicit transitive override, `Haus.Web.Host.csproj`) | 2.1.12 -> 3.0.5 | Major bump. v3 release notes: drops classic Xamarin + several `bundle_*` packages, raises .NET Framework target to 4.7.1 — none apply here (net10.0). Notes explicitly say `bundle_e_sqlite3` consumers "should Just Work," no code changes in `SQLitePCLRaw.core`. Side note: EFCore.Sqlite 10.0.11 now resolves 2.1.12 itself natively, so the override (originally added to close CVE-2025-6965) is no longer load-bearing for that CVE — kept and bumped further to stay ahead of EFCore's release cadence, comment updated to reflect current rationale. | Routine (security-adjacent) |
| `Microsoft.Playwright.NUnit` (`Haus.Acceptance.Tests`) | 1.61.0 -> 1.62.0 | Adds WebP screenshots, `Locator.WaitForFunctionAsync`, `APIResponse.TimingAsync`, clipboard isolation in headless mode. Only breaking change is dropped Debian 11 support — CI runs `ubuntu-22.04`, not applicable. | Routine |
| `dotnet-ef` local tool (`.config/dotnet-tools.json`) | 10.0.10 -> 10.0.11 | Companion patch to the .NET 10.0.11 wave; not surfaced by `dotnet-outdated` (only scans csproj `PackageReference`s, not local tools — checked manually). Dependency refreshes (SQLitePCLRaw, SqlClient), no breaking changes documented. | Routine |

`dotnet tool run dotnet-outdated Haus.slnx` now reports **no outdated dependencies**, and `dotnet list package --vulnerable --include-transitive` reports **no known-vulnerable packages** across every project.

## Gates run after every commit

- `dotnet build` — clean except one pre-existing, unrelated failure: `Haus.Acceptance.Tests`' `InstallBrowsers` post-build target requires `pwsh`, which isn't installed in this sandbox. Confirmed identical failure on unmodified `main` before any of these changes — not something this PR introduces or should fix.
- `make test-unit` — green, except 3 pre-existing `Haus.Web.Host.Tests` `ApplicationApiTests` failures (real calls to the GitHub API; this sandbox has no `GITHUB_TOKEN`/network egress). Confirmed identical failures on unmodified `main`. All other suites (`Haus.Core`, `Haus.Core.Models`, `Haus.Cqrs`, `Haus.Utilities`, `Haus.Mqtt.Client`, `Haus.Site.Host`, `Haus.Zigbee.Host`, and the other 45/48 `Haus.Web.Host.Tests`, including the Sqlite-backed `HausDbContext` tests exercising the SQLitePCLRaw bump) pass.
- `dotnet tool run csharpier check .` — clean, no formatting drift from any of these bumps.
- `dotnet ef migrations list --project src/Haus.Core --startup-project src/Haus.Web.Host` — sanity-checked the bumped `dotnet-ef` tool against this repo's real migrations; succeeds.
- `make test-acceptance` — **could not run** in this sandbox: `make publish` fails at the packaging step because `zip` isn't installed here (pre-existing environment gap, unrelated to these bumps). Should be verified in CI, which has full Playwright/zip tooling.

## Test plan

- [x] `dotnet build` (clean aside from documented pre-existing `pwsh` gap)
- [x] `make test-unit` (green aside from documented pre-existing GitHub-API test gap)
- [x] `dotnet tool run csharpier check .`
- [x] `dotnet tool run dotnet-outdated Haus.slnx` shows nothing outdated
- [x] `dotnet list package --vulnerable --include-transitive` shows nothing vulnerable
- [ ] `make test-acceptance` — blocked by sandbox missing `zip`; needs CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)