### PR TITLE
Update dependencies (Aug 2026)

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Haus.Testing.Support' AND '$(MSBuildProjectName)' != 'Haus.Acceptance.Tests'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
+++ b/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.62.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Routine dependency check-in following [PR #21](https://github.com/bryceklinker/haus/pull/21) (merged 2026-08-13, same month). Ran `dotnet tool run dotnet-outdated` against `Haus.slnx`, checked `.config/dotnet-tools.json` local tools against latest on nuget.org, and checked `global.json`'s pinned SDK against the latest published .NET 10 release notes. No npm/front-end dependencies exist in this repo.

Found one outdated dependency:

- **Microsoft.NET.Test.Sdk 18.8.1 → 18.9.0** (`tests/Directory.Build.props`, `tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj`) — bug-fix-only vstest release. Changelog ([v18.8.0...v18.9.0](https://github.com/microsoft/vstest/compare/v18.8.0...v18.9.0)) is TRX logger fixes, a blame-collector race-condition fix, testhost crash-diagnostics improvements, Native AOT compatibility for the translation layer. No breaking changes documented.

Everything else is already current as of this branch's cut from `main`:
- `Directory.Build.props`'s `MicrosoftPackageVersion` is already `10.0.11`, matching the latest .NET 10 servicing release (2026-08-11).
- All `.config/dotnet-tools.json` local tools (`dotnet-ef`, `csharpier`, `husky`, `coverlet.console`, `dotnet-reportgenerator-globaltool`, `dotnet-outdated-tool`) are already at their latest stable versions on nuget.org.
- `global.json`'s `rollForward: latestMinor` policy means the pinned baseline SDK version doesn't need to track every feature-band release.

## Test plan

- [x] `dotnet build` — green, aside from `Haus.Acceptance.Tests` failing to build in this sandbox because `pwsh` (needed for `playwright.ps1 install --with-deps`) isn't installed — confirmed this reproduces identically on unmodified `main`, unrelated to this change.
- [x] `make test-unit` — green, aside from 3 pre-existing `Haus.Web.Host.Tests.Application.ApplicationApiTests` failures caused by this sandbox lacking network egress to the real GitHub API (same limitation noted in #21) — confirmed identical on unmodified `main` before this change.
- [ ] `make test-acceptance` could not be run locally: this sandbox has neither `pwsh` nor the required Auth0 env vars (`AUTH_DOMAIN`, `AUTH_CLIENT_ID`, `AUTH_CLIENT_SECRET`, `AUTH_AUDIENCE`, `AUTH_USERNAME`, `AUTH_PASSWORD`, `GITHUB_TOKEN`, and `CYPRESS_`-prefixed variants). CI's acceptance job is the final gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)