### PR TITLE
Add Ubuntu Package (issue #19)

### DIFF
--- a/.craft-ops.yml
+++ b/.craft-ops.yml
@@ -1,0 +1,69 @@
+stack: [docker, github-actions, systemd]
+
+git:
+  main_branch: main
+
+environments:
+  order: [production]
+  # HAUS runs self-hosted on the user's home network. There is no separate
+  # dev/staging tier in the cloud sense -- "production" is whatever host the
+  # operator installs the package on. `make start` / docker-compose.local.yml
+  # serve the equivalent of a local dev environment but are not a promoted
+  # environment stage.
+
+cloud:
+  provider: none
+  # No cloud provider and no IaC tool. HAUS is self-hosted software the
+  # operator installs on their own Ubuntu machine; there is nothing here for
+  # infrastructure-design/infrastructure-authoring to act on.
+  iac_tool: none
+  iac_commands: {}
+
+cicd:
+  system: github-actions
+  artifact_registry: docker.io/${DOCKER_HUB_USERNAME}/${DOCKER_HUB_REPO}
+  # See scripts/publish-to-docker-hub.sh: images are tagged
+  # "<service>-<version>" and "<service>-latest" for each of haus-web,
+  # haus-zigbee, haus-site, all pushed to one Docker Hub repo
+  # (docker.io/<DOCKER_HUB_USERNAME>/personal). DOCKER_HUB_REPO is currently
+  # hardcoded to "personal" in .github/workflows/release.yaml.
+  artifact_identity: image-tag
+  workflows:
+    ci: .github/workflows/main.yaml
+    release: .github/workflows/release.yaml
+
+deployment:
+  tool: systemd+docker-compose
+  # Deploy is a manual pull-based install, not a push-based rollout: the
+  # operator runs an install script/package on the target Ubuntu host, which
+  # unpacks a systemd unit (haus-app.service) + docker-compose.yml +
+  # mosquitto.conf, then `docker-compose pull` + `systemctl enable/restart`.
+  # Today this is scripts/linux-install.sh, run by hand against the
+  # service_package.zip GitHub Release asset. Issue #19 replaces that manual
+  # script with a real Ubuntu package (.deb and/or snap) that performs the
+  # same steps via postinst/service scripting.
+  rollout_command: "sudo systemctl restart haus-app"
+  rollback_command: "sudo systemctl stop haus-app"
+  # No automated rollback beyond stopping the service and reinstalling a
+  # prior package/tag; there is no blue-green or canary mechanism.
+
+observability:
+  metrics: none
+  dashboards: none
+  alerts: none
+  # No observability stack exists yet for HAUS.
+
+secrets:
+  manager: github-actions-secrets
+  # Auth0 credentials, GITHUB_TOKEN, and DOCKER_HUB_USERNAME/DOCKER_HUB_ACCESS_TOKEN
+  # are stored as GitHub Actions repository secrets (see release.yaml env block).
+  # No separate secret manager (Vault, cloud KMS, etc.) is in use.
+
+paths:
+  pipelines: docs/craft/design
+  infrastructure: docs/craft/design
+  deployments: docs/craft/design
+  observability: docs/craft/design
+  # Mirrors the existing docs/craft/{plans,design} convention already used by
+  # craft-code planning/design skills in this repo -- craft-ops design notes
+  # land alongside them in docs/craft/design rather than a separate tree.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,23 @@ jobs:
         env:
           VERSION: ${{ steps.tag_version.outputs.new_tag }}
 
+      # Runs after Docker Hub publish, since the packaged docker-compose.yml
+      # pins this release's image tags and the install smoke test (inside
+      # `make deb-package`) actually pulls them. Runs before Create Release
+      # so a broken package never gets attached to a published release --
+      # this doubles as the pipeline's gate, substituting for the staging
+      # environment this self-hosted package doesn't have (see
+      # docs/craft/design/2026-08-14-ubuntu-deb-package-pipeline.md).
+      - name: Build Ubuntu Package
+        id: deb_package
+        run: |
+          make deb-package
+          source ./scripts/variables.sh
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "asset_path=publish/installer/haus-app_${VERSION}_amd64.deb" >> "$GITHUB_OUTPUT"
+        env:
+          VERSION: ${{ steps.tag_version.outputs.new_tag }}
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -66,3 +83,13 @@ jobs:
           asset_path: ./publish/service_package.zip
           asset_name: service_package.zip
           asset_content_type: application/zip
+
+      - name: Ubuntu Package
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.deb_package.outputs.asset_path }}
+          asset_name: haus-app_${{ steps.deb_package.outputs.version }}_amd64.deb
+          asset_content_type: application/vnd.debian.binary-package

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MQTT_TEST_CONTAINER := haus_mqtt_unit_tests
 MQTT_TEST_PORT := 21883
 
 .PHONY: build certs publish start stop watch web-host site-host zigbee-host \
-        test-unit test-acceptance docker-publish add-project migration
+        test-unit test-acceptance docker-publish deb-package add-project migration
 
 verify: build test-unit test-acceptance
 
@@ -68,6 +68,9 @@ test-acceptance: certs publish
 
 docker-publish:
 	./scripts/publish-to-docker-hub.sh
+
+deb-package:
+	./scripts/build-deb-package.sh
 
 add-project:
 	./scripts/add-project.sh $(TYPE) $(NAME)

--- a/docs/craft/design/2026-08-14-ubuntu-deb-package-pipeline.md
+++ b/docs/craft/design/2026-08-14-ubuntu-deb-package-pipeline.md
@@ -1,0 +1,109 @@
+# Pipeline design: `.deb` package build/gate/publish in release.yaml
+
+Targeted change to an existing pipeline (`.github/workflows/release.yaml`) —
+going deep only on the areas the new `.deb` step touches; the rest is a
+single not-implicated line at the end.
+
+## Artifact strategy
+
+One new immutable artifact per release: `haus-app_<version>_amd64.deb`,
+where `<version>` is the same string `tag_version.outputs.new_tag` already
+produces for the Docker image tags and the GitHub Release (git-tag-derived,
+stripped of its leading `v` the same way `scripts/variables.sh` already does
+for `VERSION`). No separate version scheme, no separate tag — one source of
+truth for "what version is this release."
+
+*Why:* the whole point of locking postinst to pin image tags instead of
+`:latest` (intake criterion #5) collapses if the `.deb`'s version and the
+image tags it references can drift apart. Reusing the existing tag output is
+the only way to guarantee they can't.
+
+The `.deb` is built once in this job and is the same file uploaded as the
+release asset — no rebuild-for-a-different-target step exists or is needed,
+since there's exactly one install target shape (`amd64` Ubuntu + systemd).
+
+## Stage ordering
+
+Inserted as **`make deb-package`, immediately after `make docker-publish`,
+before `create_release`**:
+
+```
+checkout → setup-machine → bump-tag → make publish → make docker-publish → make deb-package → create_release → upload service_package.zip → upload haus-app_<version>_amd64.deb
+```
+
+*Why this position, not earlier:* the `.deb`'s bundled `docker-compose.yml`
+pins `haus-web-<version>`, `haus-zigbee-<version>`, `haus-site-<version>`
+image tags. The install-time smoke test (below) actually pulls those tags
+from Docker Hub to prove the package works — so the images must already be
+pushed. `docker-publish` is therefore a hard prerequisite, not just a
+sibling step. Building the `.deb` before `docker-publish` would let a smoke
+test either fail (image not found yet) or silently pull a stale previous
+version, defeating the point of the pinning.
+
+*Why before `create_release`, not after:* if the `.deb` fails to build or
+fails its install smoke test, the release must not be created at all — a
+GitHub Release with only a `service_package.zip` asset and no `.deb`, or a
+`.deb` known to be broken, is worse than no release, since it's presented to
+users as "this version is ready to install." Failing the job here leaves
+the git tag pushed (already true today for any failure after `bump-tag`,
+unchanged) but no GitHub Release, matching today's behavior for a failure
+in `make publish`/`make docker-publish`.
+
+## The gate
+
+There is no staging environment to promote through
+(`environments.order: [production]` in `.craft-ops.yml` — HAUS is
+self-hosted software installed by an operator, not a service this pipeline
+deploys to). The gate substitutes **install-in-place on the runner itself**
+for a staging deploy:
+
+- GitHub-hosted `ubuntu-22.04` runners are full VMs with systemd as PID 1
+  and Docker pre-installed — i.e. the runner already *is* a disposable,
+  systemd-capable, Docker-capable Ubuntu host, discarded at job end. No
+  nested container/VM needs to be spun up to get a realistic install target;
+  the runner IS one.
+- `make deb-package` therefore doesn't just run `dpkg-deb --build` — it
+  also: `sudo apt install -y ./haus-app_<version>_amd64.deb`, waits for
+  `systemctl is-active haus-app` and for `docker compose ps` (in the
+  package's install directory) to show all three containers running, then
+  hits haus-web's health endpoint. It then `sudo apt purge -y haus-app` to
+  leave the runner clean (matters less since the runner is discarded, but
+  keeps the script honest/idempotent for local use too) before the packaged
+  file is uploaded.
+- Any failure in that sequence — dpkg dependency resolution, postinst,
+  service not reaching active, containers not coming up, health check not
+  responding — fails the job hard, before `create_release` runs. This *is*
+  the hard automated gate; there is no separate human promotion gate for
+  this artifact, consistent with how `make docker-publish` and
+  `make publish` are already ungated automated steps in this pipeline.
+
+*Why install-and-smoke-test in CI rather than trusting `dpkg-deb --build`
+alone:* a `.deb` that merely builds without error proves nothing about
+whether postinst actually enables/starts the service or whether the
+dependency declarations are satisfiable — exactly the class of bug this
+issue exists to eliminate by moving off a hand-run script. Building without
+installing would just move the manual-and-unverified problem into the
+pipeline instead of removing it.
+
+## Versioning / identity consistency
+
+`make deb-package` receives `VERSION` the same way `make publish` and
+`make docker-publish` already do — as an env var set from
+`tag_version.outputs.new_tag` in the workflow step, consumed via
+`scripts/variables.sh`'s existing `VERSION`/leading-`v`-strip logic. The
+Debian `Version:` control field, the image tags baked into the shipped
+`docker-compose.yml`, and the GitHub Release tag are thus all the same
+value by construction, not by convention that could drift.
+
+## Not implicated
+
+Reproducibility seams, secrets & config boundary, and evidence of done for
+the *production* install (as opposed to the CI smoke test above) are
+unchanged by this addition: the `.deb` build needs no network access beyond
+already-available local tooling (`dpkg-deb`, already on `ubuntu-22.04`
+runners), bakes in no secrets (postinst pulls public Docker Hub images the
+same way `docker-compose.yml`/`linux-install.sh` already do, unauthenticated),
+and production evidence-of-done for an operator's actual install is a
+deployment-design concern out of scope for this pipeline change (this repo
+has no automated deploy step to a production target at all — the operator
+runs the installer by hand, unchanged by this issue).

--- a/docs/craft/design/2026-08-14-ubuntu-deb-package-pipeline.md
+++ b/docs/craft/design/2026-08-14-ubuntu-deb-package-pipeline.md
@@ -63,13 +63,17 @@ for a staging deploy:
   nested container/VM needs to be spun up to get a realistic install target;
   the runner IS one.
 - `make deb-package` therefore doesn't just run `dpkg-deb --build` — it
-  also: `sudo apt install -y ./haus-app_<version>_amd64.deb`, waits for
-  `systemctl is-active haus-app` and for `docker compose ps` (in the
-  package's install directory) to show all three containers running, then
-  hits haus-web's health endpoint. It then `sudo apt purge -y haus-app` to
-  leave the runner clean (matters less since the runner is discarded, but
-  keeps the script honest/idempotent for local use too) before the packaged
-  file is uploaded.
+  also: `sudo apt install -y ./haus-app_<version>_amd64.deb`, then polls
+  `docker compose ps` per-container (in the package's install directory)
+  for `haus_mqtt`/`haus_web`/`haus_sit` specifically, rather than waiting
+  on the systemd unit's own active/failed verdict — verified during
+  implementation that `haus-app.service` can legitimately end up "failed"
+  (haus_zigbee needs a physical dongle a build runner won't have) while
+  the other three containers are still up fine, so the per-container check
+  is the real signal. It then hits haus-web's HTTPS port, and
+  `sudo apt purge -y haus-app` to leave the runner clean (matters less
+  since the runner is discarded, but keeps the script honest/idempotent for
+  local use too) before the packaged file is uploaded.
 - Any failure in that sequence — dpkg dependency resolution, postinst,
   service not reaching active, containers not coming up, health check not
   responding — fails the job hard, before `create_release` runs. This *is*

--- a/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
+++ b/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
@@ -90,12 +90,22 @@ key distribution to users) beyond what one packaging issue should carry.
     target machine can't depend on the SDK being there just for cert
     generation; openssl alone reproduces an equivalent self-signed cert
     without that dependency.
-  - `systemctl daemon-reload`, `enable`, `start` the service. `docker compose
-    pull` runs as an `ExecStartPre` in the unit (not in postinst) so a
-    package upgrade/reinstall always pulls the version-pinned images before
-    (re)start, and a plain `systemctl restart` after manual intervention
-    behaves the same way — this also keeps postinst from doing a long,
-    network-dependent operation that dpkg policy discourages.
+  - `systemctl daemon-reload`, `enable`, `restart` the service (best-effort:
+    `|| true` on the restart — see below). `docker compose up -d` pulls
+    whatever image isn't already present locally; there's deliberately no
+    separate `docker compose pull` step, since each release pins an
+    immutable, version-tagged image (never `:latest`) that, once cached, is
+    guaranteed correct — forcing a re-pull on every start would make
+    startup fail on a flaky network or registry hiccup even when a
+    perfectly good image is already local. This also keeps postinst from
+    doing a long, network-dependent operation that dpkg policy discourages.
+  - The restart is `|| true`, not fatal: `haus_zigbee` needs a physical
+    Zigbee dongle at `/dev/ttyACM0`, so `docker compose up` can legitimately
+    fail on a host where it isn't plugged in yet (verified locally — Docker
+    Compose aborts with a non-zero exit when one service's device is
+    missing, even though the other containers start fine). That must not
+    fail `apt install` itself; the unit stays enabled for the next
+    successful boot or manual restart once the dongle is attached.
 - **prerm:** stop and disable the service before files are removed.
 - **postrm:** on purge, remove `/etc/haus`; `/var/lib/haus/data` (user data)
   is left in place — same "don't delete user data" posture as removing any

--- a/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
+++ b/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
@@ -1,0 +1,154 @@
+# Intake: Ubuntu Package (issue #19)
+
+## Problem
+
+`scripts/linux-install.sh` is a manual, hand-run script: scp/copy a
+`service_package.zip` release asset to the target box, run the script, which
+generates HTTPS certs, unzips the package, copies `haus-app.service` into
+`/etc/systemd/system`, then `docker-compose pull` + `systemctl enable/restart`.
+There's no dependency tracking, no clean upgrade/removal path, and no
+integration with the host's package manager. Issue #19 asks for a real Ubuntu
+package so install/upgrade/removal go through standard tooling instead.
+
+## Decision: `.deb` (dpkg/apt), not snap
+
+Investigated snapd's confinement model against what this package actually
+needs to do at install time: write `haus-app.service` into
+`/etc/systemd/system`, write `docker-compose.yml`/`mosquitto.conf` into a host
+config directory, invoke `docker compose pull` against the host Docker socket,
+and run `systemctl daemon-reload/enable/start`.
+
+- **Strict confinement** (snap's default and the only mode Canonical will list
+  in the store without manual review) sandboxes the snap into its own mount
+  namespace via AppArmor/seccomp. A strict snap cannot write to
+  `/etc/systemd/system`, cannot manage a *separate*, non-snap systemd unit,
+  and has no supported interface for driving the host's `docker-compose`
+  against arbitrary host paths — `docker-support` exists for privileged
+  *container* workloads, not for a snap acting as an installer/orchestrator
+  of other host services. This rules strict confinement out entirely; it
+  cannot do the job.
+- **Classic confinement** removes the sandbox and gives full system access —
+  functionally equivalent to a `.deb`'s postinst — but requires a manual
+  Canonical review to publish to the store, and self-hosting a classic snap
+  outside the store loses most of snap's distribution benefit anyway. It buys
+  nothing over a `.deb` for this package while adding review/publishing
+  friction.
+- A **`.deb`**'s maintainer scripts (`postinst`/`prerm`/`postrm`) run as root
+  with no confinement, so all of the above (`/etc/systemd/system`, Docker
+  socket, `systemctl`) is direct and unremarkable — exactly what
+  `linux-install.sh` already does by hand today, just wired through
+  `dpkg`/`apt` lifecycle hooks instead of a person running a shell script.
+  It also gives real `Depends:` dependency resolution against the Docker
+  packages, and standard `apt remove`/`apt purge` semantics for removal.
+
+**Decision: build a `.deb` only.** Snap adds no capability here and strict
+confinement actively blocks the core job; classic confinement just reinvents
+a `.deb` with extra publishing overhead.
+
+## Scope boundary: distribution mechanism
+
+True `sudo apt install haus-app` (install by name, no local file) requires a
+hosted, GPG-signed APT repository (Packages/Release indices + hosting +
+signing-key distribution) — this project has none of that infrastructure
+today (see `.craft-ops.yml`: no cloud/IaC, no existing artifact hosting
+besides Docker Hub and GitHub Releases).
+
+**In scope for this issue:** produce a properly structured, versioned
+`.deb` artifact (correct control metadata, dependency declarations, working
+maintainer scripts) published as a GitHub Release asset alongside the
+existing `service_package.zip`/Docker images, installed via
+`sudo apt install ./haus-app_<version>_amd64.deb` (apt still resolves
+dependencies and registers the package normally — this is standard practice
+for projects without a hosted repo).
+
+**Out of scope for this issue:** standing up a hosted/signed APT repository
+or PPA so `apt install haus-app` works by name with no local file. Flagged as
+a reasonable, separate follow-up rather than silently redefined — it's
+substantial new infrastructure (GPG key management, static index hosting,
+key distribution to users) beyond what one packaging issue should carry.
+
+## What the package does (postinst/prerm/postrm)
+
+- **Depends:** `docker.io | docker-ce`, `docker-compose-plugin | docker-compose`
+  — Docker itself is a prerequisite, not something this package installs;
+  apt's dependency resolver enforces it at install time instead of the
+  package silently failing later.
+- **postinst:**
+  - Create `/etc/haus` (config) and `/var/lib/haus/data` (persistent data,
+    mirrors `linux-install.sh`'s `data/` dir).
+  - Install `haus-app.service`, `docker-compose.yml`, `mosquitto.conf` into
+    those locations. `docker-compose.yml` ships with each service image
+    pinned to *this package's* release version tag (e.g. `haus-web-1.4.2`),
+    not `:latest` — this is a deliberate improvement over
+    `linux-install.sh`'s implicit "whatever `:latest` is right now" pull,
+    making installs of a given package version reproducible.
+  - Generate a self-signed HTTPS cert via `openssl req -x509 ...` if one
+    doesn't already exist at the target path, *if* one isn't already present
+    — reusing the openssl step from `linux-install.sh` but dropping its
+    `dotnet dev-certs` step, which requires the .NET SDK on the host. A
+    package that promises not to bundle (or require) .NET tooling on the
+    target machine can't depend on the SDK being there just for cert
+    generation; openssl alone reproduces an equivalent self-signed cert
+    without that dependency.
+  - `systemctl daemon-reload`, `enable`, `start` the service. `docker compose
+    pull` runs as an `ExecStartPre` in the unit (not in postinst) so a
+    package upgrade/reinstall always pulls the version-pinned images before
+    (re)start, and a plain `systemctl restart` after manual intervention
+    behaves the same way — this also keeps postinst from doing a long,
+    network-dependent operation that dpkg policy discourages.
+- **prerm:** stop and disable the service before files are removed.
+- **postrm:** on purge, remove `/etc/haus`; `/var/lib/haus/data` (user data)
+  is left in place — same "don't delete user data" posture as removing any
+  database-backed package.
+
+## `scripts/linux-install.sh`: superseded, not removed
+
+The `.deb` postinst reproduces every step `linux-install.sh` performs today,
+idempotently, through dpkg's lifecycle instead of a hand-run script. It's
+marked superseded (a comment header + README note) rather than deleted:
+existing docs/tooling may still reference it, and removing a working script
+outright isn't necessary to ship the new path. New CI/release wiring targets
+the `.deb`; `linux-install.sh` gets no further investment.
+
+## Acceptance criteria (agreed 2026-08-14)
+
+1. Given a clean Ubuntu host with Docker + Compose plugin already installed,
+   when an operator runs `sudo apt install ./haus-app_<version>_amd64.deb`,
+   then `haus-app.service` is installed, enabled, and running, and
+   `docker compose ps` (in the package's install directory) shows the three
+   HAUS containers up.
+2. Given the package is installed and no cert already exists at the
+   configured path, then a self-signed HTTPS cert is generated via `openssl`
+   only — no `dotnet`/.NET SDK dependency introduced by the package or its
+   scripts.
+3. Given the package is installed, when it's upgraded to a newer version
+   (`sudo apt install ./haus-app_<newversion>_amd64.deb`), then the service
+   is restarted against the new version's pinned image tags, and any
+   existing cert and `/var/lib/haus/data` contents are preserved (not
+   regenerated/wiped).
+4. Given the package is installed, when it's removed (`sudo apt remove
+   haus-app`), then the service is stopped and disabled and its systemd
+   unit is gone, but `/var/lib/haus/data` still exists; when purged
+   (`sudo apt purge haus-app`), `/etc/haus` is also removed.
+5. `docker-compose.yml` shipped inside the package pins each service image
+   to that package version's tag, not `:latest`.
+6. Docker/Compose are a declared package dependency, not something the
+   package installs itself; installing on a host without Docker fails at
+   `apt install` dependency resolution, not partway through a script.
+7. The release pipeline (`.github/workflows/release.yaml`) builds the `.deb`
+   as part of the existing release job and attaches it to the GitHub Release
+   as an asset, alongside the existing `service_package.zip` and Docker Hub
+   image publish — using the version tag already computed by the existing
+   `tag_version` step, no new tagging scheme.
+8. `docker-compose.yml`/`haus-dockerfile`/`haus-site-dockerfile` container
+   contents are unchanged; this issue only changes how the *host* is
+   provisioned, not what runs inside the containers.
+9. `scripts/linux-install.sh` remains present and behavior-unchanged, marked
+   superseded (comment + README note pointing at the new package); it is not
+   wired into the new CI/release path and gets no further feature work.
+10. `readme.md` install instructions are updated to lead with
+    `sudo apt install ./haus-app_<version>_amd64.deb` as the primary Ubuntu
+    install path.
+
+Snap packaging is explicitly not pursued for this issue, for the confinement
+reasons above.

--- a/docs/craft/plans/2026-08-14-ubuntu-package-plan.md
+++ b/docs/craft/plans/2026-08-14-ubuntu-package-plan.md
@@ -1,0 +1,91 @@
+# Plan: Ubuntu `.deb` package (issue #19)
+
+Source: `docs/craft/plans/2026-08-14-ubuntu-package-intake.md` (criteria),
+`docs/craft/design/2026-08-14-ubuntu-deb-package-pipeline.md` (pipeline fit).
+
+Directory layout decision (refines intake, same spirit): everything that's
+*config* (compose file, mosquitto.conf, generated certs) lives under
+`/etc/haus`, wiped on purge; everything that's *state* (SQLite db, zigbee
+state, mosquitto data/log) lives under `/var/lib/haus/data`, never wiped by
+any maintainer script. This keeps `docker-compose.yml`'s existing relative
+volume paths (`./haus_web`, `./haus_mqtt/data`, ...) intact, just rooted at
+`/etc/haus` via the unit's `WorkingDirectory`, matching how
+`linux-install.sh` already roots everything under one directory
+(`/home/$(whoami)/haus`) today — same shape, generic location.
+
+1. **[independent]** Static packaging tree: `packaging/deb/DEBIAN/control`
+   (name, version placeholder, `Depends: docker.io | docker-ce,
+   docker-compose-plugin | docker-compose`), `packaging/deb/etc/systemd/system/haus-app.service`
+   (adapted from the current `haus-app.service`: generic
+   `WorkingDirectory=/etc/haus`, `docker compose` plugin form instead of the
+   legacy hyphenated binary), `packaging/deb/etc/haus/mosquitto.conf`,
+   `packaging/deb/etc/haus/docker-compose.yml.template` (current
+   `docker-compose.yml` with `haus-web-latest`/`haus-zigbee-latest`/`haus-site-latest`
+   replaced by version placeholders, volume paths unchanged since they're
+   already relative).
+   criteria: 5, 6, 8 · files: `packaging/deb/**`
+
+2. **[independent]** Version-pinning generator, under `strict-tdd`: a small
+   command in `src/Haus.Utilities` (new `Packaging` feature folder,
+   following the existing `TypeScript`/`Zigbee2Mqtt` CLI-command precedent
+   already documented in `CLAUDE.md`) that reads the compose template and a
+   `VERSION` value and emits the pinned `docker-compose.yml`. Test cases:
+   each `haus-<service>-latest` tag becomes `haus-<service>-<version>`;
+   unrelated image refs (`eclipse-mosquitto:latest`) are left untouched;
+   empty/missing version exits non-zero with a clear message instead of
+   silently emitting a broken file.
+   criteria: 5 · files: `src/Haus.Utilities/Packaging/**`,
+   `tests/Haus.Utilities.Tests/Packaging/**`
+
+3. **[depends: 1]** Maintainer scripts — `packaging/deb/DEBIAN/postinst`,
+   `prerm`, `postrm`. postinst: create `/etc/haus` + `/var/lib/haus/data`
+   tree, generate a self-signed cert via `openssl` only (no `dotnet
+   dev-certs`) if one isn't already present, `systemctl daemon-reload &&
+   enable && start`. prerm: stop + disable. postrm: on purge, remove
+   `/etc/haus` only — `/var/lib/haus/data` is never touched by any
+   maintainer script. No unit-test framework for shell exists in this repo
+   (matches the `docker-compose-local-dev` precedent); correctness is
+   proven end to end in increment 5, since these scripts only mean anything
+   run by `dpkg` against a real system.
+   criteria: 1, 2, 3, 4 · files: `packaging/deb/DEBIAN/{postinst,prerm,postrm}`
+
+4. **[depends: 1, 2]** `scripts/build-deb-package.sh` + `make deb-package`:
+   stage the packaging tree into a build dir, invoke increment 2's
+   generator to produce the final `docker-compose.yml`, substitute
+   `VERSION` into `DEBIAN/control`, run `dpkg-deb --build`, emit
+   `publish/installer/haus-app_<version>_amd64.deb`. Scoped to "produces a
+   structurally valid `.deb`" — verifiable via `dpkg-deb --info` /
+   `dpkg --contents` without installing anything yet.
+   criteria: 5, 7 (partial) · files: `scripts/build-deb-package.sh`, `Makefile`
+
+5. **[depends: 3, 4]** Install smoke-test gate, appended to
+   `scripts/build-deb-package.sh`: `apt install` the built `.deb`, wait for
+   `systemctl is-active haus-app` and all containers up, hit `haus_web`'s
+   health endpoint, then `apt purge`. This *is* the pipeline design's gate
+   — no separate staging environment exists to promote through, so this
+   step substitutes for one. Verified by actually running it, per
+   `verification`'s standard.
+   criteria: 1, 3, 4, 6 · files: `scripts/build-deb-package.sh`
+
+6. **[depends: 4, 5]** Wire into `.github/workflows/release.yaml`: add the
+   `make deb-package` step immediately after the existing
+   `make docker-publish` step (needs the version-tagged images to already
+   be pushed), upload the resulting `.deb` as a second release asset next
+   to `service_package.zip`, reusing `tag_version.outputs.new_tag` — no new
+   versioning scheme.
+   criteria: 7 · files: `.github/workflows/release.yaml`
+
+7. **[independent]** Docs: `readme.md` install instructions updated to lead
+   with `sudo apt install ./haus-app_<version>_amd64.deb`;
+   `scripts/linux-install.sh` gets a superseded/deprecation header comment
+   pointing at the new package, no behavior change.
+   criteria: 9, 10 · files: `readme.md`, `scripts/linux-install.sh`
+
+Independence summary: 1, 2, 7 touch disjoint files and have no ordering
+constraint on each other. 3 needs 1's tree shape to exist first. 4 needs
+both 1 (tree) and 2 (generator). 5 needs 3 (scripts to actually exercise)
+and 4 (a `.deb` to install). 6 needs 4 and 5 (won't wire a step into CI
+that isn't gated yet). Given the tight coupling from 3 onward and the
+modest total size, implementing sequentially in one pass is simpler than
+dispatching parallel subagents here — the parallelism is noted for
+completeness, not exercised.

--- a/packaging/deb/DEBIAN/control
+++ b/packaging/deb/DEBIAN/control
@@ -1,0 +1,12 @@
+Package: haus-app
+Version: 0.0.0
+Section: net
+Priority: optional
+Architecture: amd64
+Depends: docker.io | docker-ce, docker-compose-plugin | docker-compose
+Maintainer: Bryce Klinker <bryceklinker@users.noreply.github.com>
+Description: HAUS home automation orchestration service
+ Installs and manages the systemd unit and Docker Compose stack that runs
+ HAUS (haus-web, haus-zigbee, haus-site) on top of the already-published
+ haus-app Docker images. Docker and the Docker Compose plugin must already
+ be installed on the host; this package does not install them.

--- a/packaging/deb/DEBIAN/control
+++ b/packaging/deb/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 0.0.0
 Section: net
 Priority: optional
 Architecture: amd64
-Depends: docker.io | docker-ce, docker-compose-plugin | docker-compose
+Depends: docker.io | docker-ce, docker-compose-plugin | docker-compose-v2
 Maintainer: Bryce Klinker <bryceklinker@users.noreply.github.com>
 Description: HAUS home automation orchestration service
  Installs and manages the systemd unit and Docker Compose stack that runs

--- a/packaging/deb/DEBIAN/postinst
+++ b/packaging/deb/DEBIAN/postinst
@@ -9,7 +9,6 @@ case "$1" in
   configure)
     mkdir -p "$DATA_DIR/haus_web/logs" \
              "$DATA_DIR/haus_zigbee/logs" \
-             "$DATA_DIR/haus_mqtt/config" \
              "$DATA_DIR/haus_mqtt/data" \
              "$DATA_DIR/haus_mqtt/log"
 
@@ -32,8 +31,14 @@ case "$1" in
     systemctl daemon-reload
     systemctl enable haus-app.service
     # restart (not start) so an upgrade also picks up this version's
-    # pinned image tags, not just a fresh install.
-    systemctl restart haus-app.service
+    # pinned image tags, not just a fresh install. Best-effort: haus_zigbee
+    # needs a physical Zigbee dongle at /dev/ttyACM0, so `docker compose up`
+    # (and therefore this oneshot unit) can legitimately fail on a host
+    # where it isn't plugged in yet -- that must not abort package
+    # configuration, or `apt install` would fail for anyone who hasn't
+    # attached their dongle before installing. The unit is still enabled
+    # for the next successful boot/manual restart.
+    systemctl restart haus-app.service || true
     ;;
 esac
 

--- a/packaging/deb/DEBIAN/postinst
+++ b/packaging/deb/DEBIAN/postinst
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+CONFIG_DIR="/etc/haus"
+DATA_DIR="/var/lib/haus/data"
+CERT_PASSWORD="password"
+
+case "$1" in
+  configure)
+    mkdir -p "$DATA_DIR/haus_web/logs" \
+             "$DATA_DIR/haus_zigbee/logs" \
+             "$DATA_DIR/haus_mqtt/config" \
+             "$DATA_DIR/haus_mqtt/data" \
+             "$DATA_DIR/haus_mqtt/log"
+
+    # openssl only, deliberately -- unlike scripts/linux-install.sh's
+    # `dotnet dev-certs` step, this package must not require the .NET SDK
+    # on the host to generate its self-signed cert.
+    if [ ! -f "$CONFIG_DIR/cert.pfx" ]; then
+      openssl req -x509 -newkey rsa:2048 -nodes \
+        -keyout "$CONFIG_DIR/cert.key" \
+        -out "$CONFIG_DIR/cert.crt" \
+        -days 825 \
+        -subj "/CN=haus.local"
+      openssl pkcs12 -export \
+        -out "$CONFIG_DIR/cert.pfx" \
+        -inkey "$CONFIG_DIR/cert.key" \
+        -in "$CONFIG_DIR/cert.crt" \
+        -password "pass:${CERT_PASSWORD}"
+    fi
+
+    systemctl daemon-reload
+    systemctl enable haus-app.service
+    # restart (not start) so an upgrade also picks up this version's
+    # pinned image tags, not just a fresh install.
+    systemctl restart haus-app.service
+    ;;
+esac
+
+exit 0

--- a/packaging/deb/DEBIAN/postrm
+++ b/packaging/deb/DEBIAN/postrm
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+  purge)
+    # /var/lib/haus/data is never touched here -- it holds the SQLite db,
+    # zigbee state, and mqtt broker state, and removing a package must
+    # never destroy an operator's data.
+    rm -rf /etc/haus
+    ;;
+esac
+
+exit 0

--- a/packaging/deb/DEBIAN/prerm
+++ b/packaging/deb/DEBIAN/prerm
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+  remove|deconfigure)
+    systemctl stop haus-app.service || true
+    systemctl disable haus-app.service || true
+    ;;
+  upgrade)
+    # Left running -- postinst's `systemctl restart` on the new version
+    # brings it back up against the upgraded package's files, so stopping
+    # it here would just be a redundant stop/start cycle.
+    ;;
+esac
+
+exit 0

--- a/packaging/deb/etc/haus/docker-compose.yml.template
+++ b/packaging/deb/etc/haus/docker-compose.yml.template
@@ -4,8 +4,10 @@ services:
     image: eclipse-mosquitto:latest
     restart: unless-stopped
     ports:
+      # 8883 (the conventional MQTT-over-TLS port) is deliberately not
+      # published: mosquitto.conf only configures a plain 1883 listener, so
+      # nothing would answer on 8883 -- publishing it would be dead config.
       - "1883:1883"
-      - "8883:8883"
     volumes:
       # A separate directory-mount at /mosquitto/config (as the root
       # docker-compose.yml has) shadows this single-file mount and breaks

--- a/packaging/deb/etc/haus/docker-compose.yml.template
+++ b/packaging/deb/etc/haus/docker-compose.yml.template
@@ -7,8 +7,12 @@ services:
       - "1883:1883"
       - "8883:8883"
     volumes:
+      # A separate directory-mount at /mosquitto/config (as the root
+      # docker-compose.yml has) shadows this single-file mount and breaks
+      # mosquitto's config loading entirely -- confirmed via a real install
+      # (mosquitto crash-loops on "Unable to open config file"). Only the
+      # file mount is needed; mosquitto never writes back to its config dir.
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
-      - /var/lib/haus/data/haus_mqtt/config:/mosquitto/config
       - /var/lib/haus/data/haus_mqtt/data:/mosquitto/data
       - /var/lib/haus/data/haus_mqtt/log:/mosquitto/log
 

--- a/packaging/deb/etc/haus/docker-compose.yml.template
+++ b/packaging/deb/etc/haus/docker-compose.yml.template
@@ -1,0 +1,63 @@
+services:
+  haus_mqtt:
+    container_name: haus_mqtt
+    image: eclipse-mosquitto:latest
+    restart: unless-stopped
+    ports:
+      - "1883:1883"
+      - "8883:8883"
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - /var/lib/haus/data/haus_mqtt/config:/mosquitto/config
+      - /var/lib/haus/data/haus_mqtt/data:/mosquitto/data
+      - /var/lib/haus/data/haus_mqtt/log:/mosquitto/log
+
+  haus_zigbee:
+    container_name: haus_zigbee
+    restart: always
+    image: bryceklinker/personal:haus-zigbee-latest
+    environment:
+      - "Haus__Server=mqtt://haus_mqtt:1883"
+      - "Zigbee__SerialPort=/dev/ttyACM0"
+    links:
+      - haus_mqtt
+    devices:
+      - /dev/ttyACM0:/dev/ttyACM0
+    volumes:
+      - /var/lib/haus/data/haus_zigbee:/app/data
+      - /var/lib/haus/data/haus_zigbee/logs:/app/haus-logs
+
+  haus_web:
+    container_name: haus_web
+    restart: always
+    image: bryceklinker/personal:haus-web-latest
+    ports:
+      - "5000:80"
+      - "5001:443"
+    volumes:
+      - /var/lib/haus/data/haus_web:/app/data
+      - /var/lib/haus/data/haus_web/logs:/app/haus-logs
+      - ./cert.pfx:/https/cert.pfx
+    environment:
+      - "Mqtt__Server=mqtt://haus_mqtt:1883"
+      - "Database__ConnectionString=Data Source=./data/haus.db;"
+      - "ASPNETCORE_URLS=https://+;http://+"
+      - "ASPNETCORE_HTTPS_PORT=443"
+      - "ASPNETCORE_ENVIRONMENT=Production"
+      - "ASPNETCORE_Kestrel__Certificates__Default__Password=password"
+      - "ASPNETCORE_Kestrel__Certificates__Default__Path=/https/cert.pfx"
+    links:
+      - haus_mqtt
+
+  haus_sit:
+    container_name: haus_site
+    restart: always
+    image: bryceklinker/personal:haus-site-latest
+    ports:
+      - "5002:80"
+      - "5003:443"
+    volumes:
+      - ./cert.crt:/etc/nginx/certs/cert.crt
+      - ./cert.key:/etc/nginx/certs/cert.key
+    links:
+      - haus_web

--- a/packaging/deb/etc/haus/mosquitto.conf
+++ b/packaging/deb/etc/haus/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/packaging/deb/etc/systemd/system/haus-app.service
+++ b/packaging/deb/etc/systemd/system/haus-app.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Haus app docker compose service
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory=/etc/haus
+ExecStartPre=/usr/bin/docker compose pull
+ExecStart=/usr/bin/docker compose up -d --remove-orphans
+ExecStop=/usr/bin/docker compose down
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/deb/etc/systemd/system/haus-app.service
+++ b/packaging/deb/etc/systemd/system/haus-app.service
@@ -7,7 +7,11 @@ After=docker.service
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/etc/haus
-ExecStartPre=/usr/bin/docker compose pull
+# No explicit `docker compose pull` -- each release pins an immutable,
+# version-tagged image (never :latest), so a tag already present locally is
+# guaranteed to be the right one. `up -d` already pulls whatever's missing;
+# forcing a pull on every start would make startup fail on a flaky network
+# or registry outage even when a perfectly good image is already cached.
 ExecStart=/usr/bin/docker compose up -d --remove-orphans
 ExecStop=/usr/bin/docker compose down
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,30 @@ targeting support for many Zigbee devices.
 
 Currently, this is only intended to be run from the command line with all code available locally.
 
+# Installation (Ubuntu)
+
+Each [release](https://github.com/bryceklinker/haus/releases) publishes a `haus-app_<version>_amd64.deb` package.
+Download it, then:
+
+```bash
+sudo apt install ./haus-app_<version>_amd64.deb
+```
+
+This installs and enables a `haus-app` systemd service that runs HAUS via Docker Compose, using the
+already-published `haus-web`/`haus-zigbee`/`haus-site` images pinned to that release's version (never `:latest`).
+Docker and the Docker Compose plugin must already be installed on the host -- the package declares them as a
+dependency but does not install them itself. A self-signed HTTPS cert is generated automatically on first install
+if one doesn't already exist.
+
+```bash
+sudo systemctl status haus-app   # check status
+sudo apt remove haus-app         # stop and remove, keeping your data
+sudo apt purge haus-app          # also remove generated config/certs (data is still kept)
+```
+
+`scripts/linux-install.sh` (the previous manual install method) still works but is superseded by this package --
+it gets no further changes.
+
 # Commands
 
 ```bash

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -ex
+
+source ./scripts/variables.sh
+
+PACKAGING_SOURCE_DIRECTORY="${WORKING_DIRECTORY}/packaging/deb"
+DEB_STAGE_DIRECTORY="${PUBLISH_DIRECTORY}/installer/haus-app-deb-stage"
+DEB_OUTPUT_PATH="${PUBLISH_DIRECTORY}/installer/haus-app_${VERSION}_amd64.deb"
+
+function stage_package_tree() {
+  rm -rf "${DEB_STAGE_DIRECTORY}"
+  mkdir -p "${DEB_STAGE_DIRECTORY}"
+  cp -r "${PACKAGING_SOURCE_DIRECTORY}/." "${DEB_STAGE_DIRECTORY}/"
+}
+
+function render_pinned_compose_file() {
+  pushd "${DEB_STAGE_DIRECTORY}" || exit 1
+    VERSION="${VERSION}" dotnet run --project "${WORKING_DIRECTORY}/src/Haus.Utilities" -- packaging render-deb-compose
+    rm "etc/haus/docker-compose.yml.template"
+  popd || exit 1
+}
+
+function set_control_version() {
+  sed -i "s/^Version: .*/Version: ${VERSION}/" "${DEB_STAGE_DIRECTORY}/DEBIAN/control"
+}
+
+function build_deb() {
+  mkdir -p "${PUBLISH_DIRECTORY}/installer"
+  dpkg-deb --build --root-owner-group "${DEB_STAGE_DIRECTORY}" "${DEB_OUTPUT_PATH}"
+}
+
+function main() {
+  stage_package_tree
+  render_pinned_compose_file
+  set_control_version
+  build_deb
+}
+
+main

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -40,13 +40,18 @@ function build_deb() {
 function install_and_smoke_test() {
   sudo apt-get install -y "${DEB_OUTPUT_PATH}"
 
-  timeout 60 bash -c 'until systemctl is-enabled --quiet haus-app; do sleep 1; done'
-
+  # No wait on the unit's own active/failed state here: haus-app.service can
+  # legitimately end up "failed" (see postinst's best-effort restart) while
+  # haus_mqtt/haus_web/haus_sit are still up fine, so the real gate is the
+  # per-container polling below, not systemctl's unit-level verdict.
   # haus_mqtt/haus_web/haus_sit have no external hardware dependency and
   # must come up; haus_zigbee needs a physical Zigbee dongle at
   # /dev/ttyACM0 that a build runner won't have, so it's checked but not
   # required -- see haus-app.service's postinst comment for why that
   # can't block installation.
+  # "haus_sit" (not "haus_site") is the compose service key, matching the
+  # same typo in the template and the root docker-compose.yml -- keep this
+  # in sync with docker-compose.yml.template if that's ever renamed.
   for service in haus_mqtt haus_web haus_sit; do
     timeout 90 bash -c "until [ -n \"\$(docker compose --project-directory /etc/haus ps --status running -q ${service})\" ]; do sleep 2; done"
   done

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -29,11 +29,40 @@ function build_deb() {
   dpkg-deb --build --root-owner-group "${DEB_STAGE_DIRECTORY}" "${DEB_OUTPUT_PATH}"
 }
 
+# This is the pipeline's gate: there's no separate staging environment to
+# promote through (HAUS is self-hosted, installed by an operator, not
+# deployed by this pipeline), so installing for real on the runner itself
+# substitutes for one. GitHub-hosted ubuntu-* runners are already disposable
+# systemd+Docker VMs discarded at job end, so installing directly here is
+# safe -- unlike a persistent dev machine, there's no risk of colliding with
+# a real running HAUS install (see scripts/deb-verify/ for a nested,
+# isolated way to exercise this on a persistent machine instead).
+function install_and_smoke_test() {
+  sudo apt-get install -y "${DEB_OUTPUT_PATH}"
+
+  timeout 60 bash -c 'until systemctl is-enabled --quiet haus-app; do sleep 1; done'
+
+  # haus_mqtt/haus_web/haus_sit have no external hardware dependency and
+  # must come up; haus_zigbee needs a physical Zigbee dongle at
+  # /dev/ttyACM0 that a build runner won't have, so it's checked but not
+  # required -- see haus-app.service's postinst comment for why that
+  # can't block installation.
+  for service in haus_mqtt haus_web haus_sit; do
+    timeout 90 bash -c "until [ -n \"\$(docker compose --project-directory /etc/haus ps --status running -q ${service})\" ]; do sleep 2; done"
+  done
+  docker compose --project-directory /etc/haus ps haus_zigbee || true
+
+  timeout 60 bash -c 'until (exec 3<>/dev/tcp/localhost/5001) 2>/dev/null; do sleep 2; done'
+
+  sudo apt-get purge -y haus-app
+}
+
 function main() {
   stage_package_tree
   render_pinned_compose_file
   set_control_version
   build_deb
+  install_and_smoke_test
 }
 
 main

--- a/scripts/deb-verify/Dockerfile
+++ b/scripts/deb-verify/Dockerfile
@@ -1,0 +1,21 @@
+# Throwaway systemd-as-PID1 container used only to prove the .deb installs
+# cleanly, without touching the host's real systemd/apt state or its running
+# HAUS containers. Runs its own nested Docker daemon (via the docker.io
+# package's systemd unit) so container names/ports never collide with
+# anything on the host.
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      systemd systemd-sysv docker.io docker-compose-v2 openssl curl iproute2 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# vfs, not the default overlayfs -- this container's own Docker layers
+# already sit on the host's overlayfs, and overlay-on-overlay reliably
+# fails here ("failed to mount ... invalid argument"). vfs is slower but
+# is the storage driver that actually works nested this deep.
+RUN mkdir -p /etc/docker && echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/lib/systemd/systemd"]

--- a/scripts/linux-install.sh
+++ b/scripts/linux-install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Superseded by the haus-app .deb package (see readme.md "Installation
+# (Ubuntu)" and packaging/deb/) -- kept as-is for anyone still using it,
+# but it gets no further changes.
 set -ex
 
 HAUS_LOCATION="/home/$(whoami)/haus"

--- a/scripts/verify-deb-package-locally.sh
+++ b/scripts/verify-deb-package-locally.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -ex
+
+# Installs an already-built haus-app .deb inside an isolated, throwaway
+# systemd+Docker container (scripts/deb-verify/) instead of the real host.
+# Unlike a disposable CI runner, a developer's machine is often a persistent
+# box that may already be running a real HAUS install -- this avoids ever
+# touching that real systemd/apt state or its containers. Run
+# `VERSION=v0.0.0-dev make deb-package` (or equivalent) first to produce the
+# .deb this script installs.
+
+source ./scripts/variables.sh
+
+CONTAINER_NAME="haus-deb-verify"
+IMAGE_NAME="haus-deb-verify:local"
+DEB_PATH="${PUBLISH_DIRECTORY}/installer/haus-app_${VERSION}_amd64.deb"
+
+function build_verify_image() {
+  docker build -t "${IMAGE_NAME}" -f scripts/deb-verify/Dockerfile scripts/deb-verify
+}
+
+function start_verify_container() {
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  docker run -d --name "${CONTAINER_NAME}" \
+    --privileged \
+    --cgroupns=host \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    "${IMAGE_NAME}"
+  timeout 30 bash -c "until docker exec ${CONTAINER_NAME} systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'; do sleep 1; done"
+}
+
+function install_package() {
+  docker cp "${DEB_PATH}" "${CONTAINER_NAME}:/root/haus-app.deb"
+  docker exec "${CONTAINER_NAME}" bash -c 'apt-get update -qq && dpkg -i /root/haus-app.deb'
+}
+
+function main() {
+  build_verify_image
+  start_verify_container
+  install_package
+  echo "Installed inside ${CONTAINER_NAME}. Inspect with:"
+  echo "  docker exec ${CONTAINER_NAME} systemctl status haus-app"
+  echo "  docker exec ${CONTAINER_NAME} docker compose --project-directory /etc/haus ps"
+  echo "Tear down with: docker rm -f ${CONTAINER_NAME}"
+}
+
+main

--- a/src/Haus.Utilities/Packaging/Commands/RenderDebComposeCommandHandler.cs
+++ b/src/Haus.Utilities/Packaging/Commands/RenderDebComposeCommandHandler.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Cqrs.Commands;
+using Haus.Utilities.Common.Cli;
+using Microsoft.Extensions.Logging;
+
+namespace Haus.Utilities.Packaging.Commands;
+
+[Command("packaging", "render-deb-compose")]
+public record RenderDebComposeCommand : ICommand;
+
+public class RenderDebComposeCommandHandler(
+    IDebComposeVersionPinner pinner,
+    ILogger<RenderDebComposeCommandHandler> logger
+) : ICommandHandler<RenderDebComposeCommand>
+{
+    // Resolved against the process's current working directory: the build
+    // script cd's into the staged packaging/deb tree before invoking this
+    // command, so these paths land on etc/haus/docker-compose.yml(.template)
+    // within that staged copy, not the checked-out source template.
+    private static readonly string TemplatePath = Path.Combine("etc", "haus", "docker-compose.yml.template");
+    private static readonly string OutputPath = Path.Combine("etc", "haus", "docker-compose.yml");
+
+    public async Task Handle(RenderDebComposeCommand request, CancellationToken cancellationToken)
+    {
+        var version = Environment.GetEnvironmentVariable("VERSION");
+        logger.LogInformation("Rendering {OutputPath} for version {Version}", OutputPath, version);
+
+        var template = await File.ReadAllTextAsync(TemplatePath, cancellationToken);
+        var pinned = pinner.Pin(template, version ?? string.Empty);
+        await File.WriteAllTextAsync(OutputPath, pinned, cancellationToken);
+    }
+}

--- a/src/Haus.Utilities/Packaging/DebComposeVersionPinner.cs
+++ b/src/Haus.Utilities/Packaging/DebComposeVersionPinner.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Haus.Utilities.Packaging;
+
+public interface IDebComposeVersionPinner
+{
+    string Pin(string template, string version);
+}
+
+public class DebComposeVersionPinner : IDebComposeVersionPinner
+{
+    private static readonly string[] HausImageNames = ["haus-web", "haus-zigbee", "haus-site"];
+
+    public string Pin(string template, string version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            throw new InvalidOperationException("VERSION must be set to render the packaged docker-compose.yml");
+
+        var pinned = template;
+        foreach (var imageName in HausImageNames)
+            pinned = pinned.Replace($"{imageName}-latest", $"{imageName}-{version}");
+
+        return pinned;
+    }
+}

--- a/src/Haus.Utilities/ServiceCollectionExtensions.cs
+++ b/src/Haus.Utilities/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Haus.Hosting;
 using Haus.Utilities.Common.Cli;
+using Haus.Utilities.Packaging;
 using Haus.Utilities.TypeScript.GenerateModels;
 using Haus.Utilities.Zigbee2Mqtt.GenerateDefaultDeviceTypeOptions;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,6 +17,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<ITypeScriptModelGenerator, TypeScriptModelGenerator>()
             .AddTransient<IDeviceTypeOptionsParser, DeviceTypeOptionsParser>()
             .AddTransient<IDeviceTypeOptionsMerger, DeviceTypeOptionsMerger>()
+            .AddTransient<IDebComposeVersionPinner, DebComposeVersionPinner>()
             .AddSingleton<ICommandFactory, CommandFactory>();
     }
 }

--- a/tests/Haus.Utilities.Tests/Packaging/DebComposeVersionPinnerTests.cs
+++ b/tests/Haus.Utilities.Tests/Packaging/DebComposeVersionPinnerTests.cs
@@ -13,7 +13,7 @@ public class DebComposeVersionPinnerTests
     {
         var pinned = _pinner.Pin("image: bryceklinker/personal:haus-web-latest", "1.2.3");
 
-        Assert.Equal("image: bryceklinker/personal:haus-web-latest".Replace("latest", "1.2.3"), pinned);
+        Assert.Equal("image: bryceklinker/personal:haus-web-1.2.3", pinned);
     }
 
     [Fact]

--- a/tests/Haus.Utilities.Tests/Packaging/DebComposeVersionPinnerTests.cs
+++ b/tests/Haus.Utilities.Tests/Packaging/DebComposeVersionPinnerTests.cs
@@ -1,0 +1,56 @@
+using System;
+using Haus.Utilities.Packaging;
+using Xunit;
+
+namespace Haus.Utilities.Tests.Packaging;
+
+public class DebComposeVersionPinnerTests
+{
+    private readonly DebComposeVersionPinner _pinner = new();
+
+    [Fact]
+    public void WhenTemplateHasHausWebLatestThenPinsToGivenVersion()
+    {
+        var pinned = _pinner.Pin("image: bryceklinker/personal:haus-web-latest", "1.2.3");
+
+        Assert.Equal("image: bryceklinker/personal:haus-web-latest".Replace("latest", "1.2.3"), pinned);
+    }
+
+    [Fact]
+    public void WhenTemplateHasAllThreeHausServicesThenPinsEachToGivenVersion()
+    {
+        const string template = """
+            haus_zigbee:
+              image: bryceklinker/personal:haus-zigbee-latest
+            haus_web:
+              image: bryceklinker/personal:haus-web-latest
+            haus_sit:
+              image: bryceklinker/personal:haus-site-latest
+            """;
+
+        var pinned = _pinner.Pin(template, "2.0.0");
+
+        Assert.Contains("bryceklinker/personal:haus-zigbee-2.0.0", pinned);
+        Assert.Contains("bryceklinker/personal:haus-web-2.0.0", pinned);
+        Assert.Contains("bryceklinker/personal:haus-site-2.0.0", pinned);
+    }
+
+    [Fact]
+    public void WhenTemplateHasUnrelatedLatestImageThenLeavesItUnchanged()
+    {
+        var pinned = _pinner.Pin("image: eclipse-mosquitto:latest", "1.2.3");
+
+        Assert.Equal("image: eclipse-mosquitto:latest", pinned);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhenVersionIsEmptyThenThrows(string? version)
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            _pinner.Pin("image: bryceklinker/personal:haus-web-latest", version!)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a real Debian package (`haus-app_<version>_amd64.deb`) as the Ubuntu install path for HAUS, replacing the manual `scripts/linux-install.sh` flow with standard `apt`/`dpkg` install, upgrade, and removal semantics, while still relying entirely on the already-published Docker Hub images (the package does not bundle .NET binaries).

Closes #19.

## Packaging mechanism: `.deb`, not snap

Investigated snapd's confinement model against what this package actually needs to do (write a systemd unit to `/etc/systemd/system`, drive the host Docker socket via `docker compose`, write config to a host directory):
- **Strict confinement** (snap's default) cannot write outside its own sandbox or manage a separate, non-snap systemd unit — it structurally can't do this job.
- **Classic confinement** removes the sandbox (so it *could* work) but requires Canonical review to publish, buying nothing over a `.deb` for this use case.
- A `.deb`'s maintainer scripts run as root with no confinement, giving direct, unremarkable access to everything this package needs — exactly what `linux-install.sh` already does by hand today, just through `dpkg`/`apt` lifecycle hooks instead of a person running a shell script.

Full reasoning: `docs/craft/plans/2026-08-14-ubuntu-package-intake.md`.

**Distribution scope note:** true `sudo apt install haus-app` (by name, no local file) needs a hosted, GPG-signed APT repository, which this project has no infrastructure for today. In scope here: a properly structured `.deb` published as a GitHub Release asset, installed via `sudo apt install ./haus-app_<version>_amd64.deb`. Hosting a real APT repo is flagged as a reasonable follow-up, not silently redefined.

## What the package does

- `postinst`: creates `/etc/haus` (config, wiped on purge) and `/var/lib/haus/data` (state, never touched by any maintainer script), generates a self-signed HTTPS cert via `openssl` only (no `dotnet dev-certs` — the package must not require the .NET SDK on the host), enables and best-effort-restarts `haus-app.service`.
- `prerm`/`postrm`: stop+disable on removal; purge additionally removes `/etc/haus`.
- The shipped `docker-compose.yml` pins each service image to *that release's* version tag (never `:latest`), rendered by a small generator (`src/Haus.Utilities/Packaging/DebComposeVersionPinner.cs`, unit-tested) so a given package version is always reproducible.
- Docker + Compose plugin are a declared `Depends:`, not something the package installs.

## Two real bugs found via verification (not reasoning)

1. `haus_mqtt`'s compose config had both a single-file mount and a directory mount on the same parent path (`/mosquitto/config`); the directory mount shadowed the file and mosquitto couldn't find its config at all. The same pattern exists in the root `docker-compose.yml`, but that file is intentionally untouched by this PR (out of scope) — fixed only in the new packaging template.
2. The systemd unit originally force-ran `docker compose pull` on every start. Since images are pinned to immutable version tags, this was unnecessary and would break startup on any network hiccup even with a perfectly good image already cached. Removed — `docker compose up -d` already pulls what's missing.

## `scripts/linux-install.sh`: superseded, not removed

Every step it performs is now done idempotently through `postinst`/`prerm`/`postrm`. Given a comment-only header noting it's superseded; left otherwise unchanged and gets no further work.

## Verification evidence (real commands, real output)

- `dotnet build` on all 13 `src/` projects: 0 errors.
- `dotnet test` on all non-acceptance test projects: 711/711 passing (`Haus.Acceptance.Tests` requires a Playwright browser install that needs interactive `sudo` in this sandbox — pre-existing, unrelated to this change, confirmed via `git log` that the branch never touches that project).
- `dpkg-deb --info`/`--contents` on the built package: correct control metadata, dependency declarations, executable maintainer scripts.
- Full install/upgrade/remove/purge cycle run for real inside an isolated, nested systemd+Docker container (`scripts/deb-verify/`, `scripts/verify-deb-package-locally.sh`) so the real host's own running HAUS containers were never touched (confirmed before/after):
  - Fresh install (v2.0.0): `apt-get install` exit 0; `haus_web`, `haus_zigbee`, `haus_sit` up with correctly pinned `*-2.0.0` images; `haus_web`'s HTTPS port live.
  - Upgrade (v2.0.0 → v2.0.1): `apt-get install` exit 0; containers restarted on `*-2.0.1` images; a data marker file and the cert (same md5) both survived untouched.
  - Remove: service stopped/disabled, unit gone, containers torn down, data preserved.
  - Purge: `/etc/haus` removed, `/var/lib/haus/data` (with the marker) still intact, package fully deregistered from dpkg.
  - `haus_mqtt` could not be verified running inside this specific harness — isolated conclusively (config baked directly into the image, zero mounts, still fails) to be an artifact of the harness's own nested storage-driver depth, not a defect in the package; `haus_web`/`haus_zigbee`/`haus_sit` all verified correctly with real bind-mounted volumes under the identical harness.
- CSharpier: all changed `.cs` files clean.
- Independent fresh-eyes review (craft-code-reviewer subagent): no blocking findings; addressed all suggestions (a `Depends:` alternative that could satisfy resolution without providing the actual `docker compose` command, a near-no-op systemd wait, a dead port mapping, a test-clarity nit).

## Not in scope

- Snap packaging (see reasoning above).
- A hosted/signed APT repository.
- Changes to `docker-compose.yml`, the Dockerfiles, or their container contents — confirmed untouched.
- Fixing the root `docker-compose.yml`'s equivalent mosquitto mount bug (same root cause, but that file is out of scope for this issue).