### PR TITLE
Add Conventional Commits convention with Husky.Net enforcement

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+COMMIT_MSG_FILE="$1" dotnet husky run --group commit-msg

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-dotnet husky run
+dotnet husky run --group pre-commit

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -3,15 +3,23 @@
    "tasks": [
       {
          "name": "format",
+         "group": "pre-commit",
          "command": "dotnet",
          "args": ["format", "--include", "${staged}"],
          "include": ["**/*.cs"]
       },
       {
          "name": "CSharpier",
+         "group": "pre-commit",
          "command": "dotnet",
          "args": [ "csharpier", "format", "${staged}" ],
          "include": ["**/*.cs"]
+      },
+      {
+         "name": "conventional-commit-message",
+         "group": "commit-msg",
+         "command": "dotnet",
+         "args": ["run", "--project", "src/Haus.Utilities", "--", "git", "validate-commit-message"]
       }
    ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,11 @@ Coverage/build variables (VERSION, CONFIGURATION, publish/coverage paths) live i
 
 ### Formatting / linting
 
-CSharpier + `dotnet format` run automatically on staged `*.cs` files via Husky.Net (`.husky/pre-commit` → `dotnet husky run`, tasks defined in `.husky/task-runner.json`). CSharpier config is in `.csharpierrc.json` (4-space indent, 120 col width). Don't bypass this hook.
+CSharpier + `dotnet format` run automatically on staged `*.cs` files via Husky.Net (`.husky/pre-commit` → `dotnet husky run --group pre-commit`, tasks defined in `.husky/task-runner.json`). CSharpier config is in `.csharpierrc.json` (4-space indent, 120 col width). Don't bypass this hook.
+
+### Commit messages
+
+Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`) — see `CONTRIBUTING.md` for the allowed types and why (it drives git-cliff release notes). Enforced by a Husky.Net `commit-msg` hook (`.husky/commit-msg` → `dotnet husky run --group commit-msg`), backed by `Haus.Utilities`' `git validate-commit-message` CLI command (`src/Haus.Utilities/Git`).
 
 ### EF Core migrations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+## Commit messages
+
+This repository follows [Conventional Commits](https://www.conventionalcommits.org/). The format matters here specifically
+because commit history drives automated release notes ([git-cliff](https://git-cliff.org/)) — the type of each commit
+determines which section of the changelog it lands in, and a `!` marks a breaking change for versioning purposes.
+
+```
+<type>(<optional scope>): <description>
+```
+
+Examples:
+
+```
+feat: add device discovery
+fix(zigbee): handle disconnect race
+docs: document commit conventions
+feat(api)!: change device response shape
+```
+
+Allowed types:
+
+| Type       | Use for |
+|------------|---------|
+| `feat`     | A new feature |
+| `fix`      | A bug fix |
+| `docs`     | Documentation only |
+| `style`    | Formatting/whitespace, no code meaning change |
+| `refactor` | Neither fixes a bug nor adds a feature |
+| `perf`     | A performance improvement |
+| `test`     | Adding or correcting tests |
+| `build`    | Build system or packaging changes |
+| `ci`       | CI configuration changes |
+| `chore`    | Anything else that doesn't modify src or test files |
+| `revert`   | Reverts a previous commit |
+
+The scope is optional and should name the affected area (e.g. `zigbee`, `web-host`, `site`, `utilities`).
+
+A `!` immediately before the colon (optionally after the scope) marks a breaking change, e.g. `feat(api)!: ...`.
+
+This is enforced by a Husky.Net `commit-msg` git hook (`.husky/commit-msg`), which rejects commits whose message doesn't
+match this format. Git-generated `Merge` and `Revert "..."` commit messages are exempt.
+
+## Formatting
+
+CSharpier and `dotnet format` run automatically on staged `*.cs` files via a Husky.Net `pre-commit` hook. Don't bypass it.

--- a/src/Haus.Utilities/Git/Commands/ValidateCommitMessageCommandHandler.cs
+++ b/src/Haus.Utilities/Git/Commands/ValidateCommitMessageCommandHandler.cs
@@ -27,7 +27,7 @@ public class ValidateCommitMessageCommandHandler(
         var commitMessage = await File.ReadAllTextAsync(commitMessageFilePath, cancellationToken);
         var result = validator.Validate(commitMessage);
         if (!result.IsValid)
-            throw new InvalidCommitMessageException(result.Error!);
+            throw new InvalidCommitMessageException(result.Error);
 
         logger.LogInformation("Commit message is valid.");
     }

--- a/src/Haus.Utilities/Git/Commands/ValidateCommitMessageCommandHandler.cs
+++ b/src/Haus.Utilities/Git/Commands/ValidateCommitMessageCommandHandler.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Cqrs.Commands;
+using Haus.Utilities.Common.Cli;
+using Microsoft.Extensions.Logging;
+
+namespace Haus.Utilities.Git.Commands;
+
+[Command("git", "validate-commit-message")]
+public record ValidateCommitMessageCommand : ICommand;
+
+public class InvalidCommitMessageException(string message) : Exception(message);
+
+public class ValidateCommitMessageCommandHandler(
+    IConventionalCommitMessageValidator validator,
+    ILogger<ValidateCommitMessageCommandHandler> logger
+) : ICommandHandler<ValidateCommitMessageCommand>
+{
+    public async Task Handle(ValidateCommitMessageCommand request, CancellationToken cancellationToken)
+    {
+        var commitMessageFilePath = Environment.GetEnvironmentVariable("COMMIT_MSG_FILE");
+        if (string.IsNullOrWhiteSpace(commitMessageFilePath))
+            throw new InvalidOperationException("COMMIT_MSG_FILE environment variable was not set.");
+
+        var commitMessage = await File.ReadAllTextAsync(commitMessageFilePath, cancellationToken);
+        var result = validator.Validate(commitMessage);
+        if (!result.IsValid)
+            throw new InvalidCommitMessageException(result.Error!);
+
+        logger.LogInformation("Commit message is valid.");
+    }
+}

--- a/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
+++ b/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
@@ -10,7 +10,12 @@ public record CommitMessageValidationResult(bool IsValid, string? Error)
     public static CommitMessageValidationResult Invalid(string error) => new(false, error);
 }
 
-public class ConventionalCommitMessageValidator
+public interface IConventionalCommitMessageValidator
+{
+    CommitMessageValidationResult Validate(string commitMessage);
+}
+
+public class ConventionalCommitMessageValidator : IConventionalCommitMessageValidator
 {
     private static readonly string[] AllowedTypes =
     [

--- a/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
+++ b/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
@@ -3,9 +3,9 @@ using System.Text.RegularExpressions;
 
 namespace Haus.Utilities.Git;
 
-public record CommitMessageValidationResult(bool IsValid, string? Error)
+public record CommitMessageValidationResult(bool IsValid, string Error)
 {
-    public static CommitMessageValidationResult Valid() => new(true, null);
+    public static CommitMessageValidationResult Valid() => new(true, string.Empty);
 
     public static CommitMessageValidationResult Invalid(string error) => new(false, error);
 }
@@ -51,9 +51,14 @@ public class ConventionalCommitMessageValidator : IConventionalCommitMessageVali
 
     private static string FirstLine(string commitMessage)
     {
-        var newlineIndex = commitMessage.IndexOf('\n');
-        var header = newlineIndex >= 0 ? commitMessage[..newlineIndex] : commitMessage;
-        return header.Trim();
+        foreach (var line in commitMessage.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0)
+                return trimmed;
+        }
+
+        return string.Empty;
     }
 
     private static bool IsGitGeneratedHeader(string header) =>

--- a/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
+++ b/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Haus.Utilities.Git;
+
+public record CommitMessageValidationResult(bool IsValid, string? Error)
+{
+    public static CommitMessageValidationResult Valid() => new(true, null);
+
+    public static CommitMessageValidationResult Invalid(string error) => new(false, error);
+}
+
+public class ConventionalCommitMessageValidator
+{
+    private static readonly string[] AllowedTypes =
+    [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert",
+    ];
+
+    private static readonly Regex HeaderPattern = new(
+        $"^({string.Join('|', AllowedTypes)})(\\([a-z0-9/_-]+\\))?!?: \\S.*$",
+        RegexOptions.Compiled
+    );
+
+    public CommitMessageValidationResult Validate(string commitMessage)
+    {
+        var header = FirstLine(commitMessage);
+
+        if (IsGitGeneratedHeader(header))
+            return CommitMessageValidationResult.Valid();
+
+        return HeaderPattern.IsMatch(header)
+            ? CommitMessageValidationResult.Valid()
+            : CommitMessageValidationResult.Invalid(BuildError(header));
+    }
+
+    private static string FirstLine(string commitMessage)
+    {
+        var newlineIndex = commitMessage.IndexOf('\n');
+        var header = newlineIndex >= 0 ? commitMessage[..newlineIndex] : commitMessage;
+        return header.Trim();
+    }
+
+    private static bool IsGitGeneratedHeader(string header) =>
+        header.StartsWith("Merge ", StringComparison.Ordinal)
+        || header.StartsWith("Revert \"", StringComparison.Ordinal);
+
+    private static string BuildError(string header) =>
+        $"""
+            Invalid commit message: "{header}"
+
+            Commit messages must follow Conventional Commits format:
+              type(scope): description
+
+            Allowed types: {string.Join(", ", AllowedTypes)}
+
+            Examples:
+              feat: add device discovery
+              fix(zigbee): handle disconnect race
+              feat(api)!: change device response shape
+
+            See CONTRIBUTING.md for details.
+            """;
+}

--- a/src/Haus.Utilities/ServiceCollectionExtensions.cs
+++ b/src/Haus.Utilities/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Haus.Hosting;
 using Haus.Utilities.Common.Cli;
+using Haus.Utilities.Git;
 using Haus.Utilities.Packaging;
 using Haus.Utilities.TypeScript.GenerateModels;
 using Haus.Utilities.Zigbee2Mqtt.GenerateDefaultDeviceTypeOptions;
@@ -18,6 +19,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IDeviceTypeOptionsParser, DeviceTypeOptionsParser>()
             .AddTransient<IDeviceTypeOptionsMerger, DeviceTypeOptionsMerger>()
             .AddTransient<IDebComposeVersionPinner, DebComposeVersionPinner>()
+            .AddTransient<IConventionalCommitMessageValidator, ConventionalCommitMessageValidator>()
             .AddSingleton<ICommandFactory, CommandFactory>();
     }
 }

--- a/tests/Haus.Utilities.Tests/Git/ConventionalCommitMessageValidatorTests.cs
+++ b/tests/Haus.Utilities.Tests/Git/ConventionalCommitMessageValidatorTests.cs
@@ -126,4 +126,36 @@ public class ConventionalCommitMessageValidatorTests
 
         Assert.True(result.IsValid);
     }
+
+    [Fact]
+    public void WhenValidThenErrorIsEmpty()
+    {
+        var result = _validator.Validate("feat: add device discovery");
+
+        Assert.Equal(string.Empty, result.Error);
+    }
+
+    [Fact]
+    public void WhenMessageHasLeadingBlankLinesThenFirstNonBlankLineIsTheHeader()
+    {
+        var result = _validator.Validate("\n\nfeat: add device discovery");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenHeaderHasBreakingChangeMarkerWithNoScopeThenIsValid()
+    {
+        var result = _validator.Validate("feat!: change device response shape");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenScopeHasUppercaseCharactersThenIsInvalid()
+    {
+        var result = _validator.Validate("feat(API): change device response shape");
+
+        Assert.False(result.IsValid);
+    }
 }

--- a/tests/Haus.Utilities.Tests/Git/ConventionalCommitMessageValidatorTests.cs
+++ b/tests/Haus.Utilities.Tests/Git/ConventionalCommitMessageValidatorTests.cs
@@ -1,0 +1,129 @@
+using Haus.Utilities.Git;
+using Xunit;
+
+namespace Haus.Utilities.Tests.Git;
+
+public class ConventionalCommitMessageValidatorTests
+{
+    private readonly ConventionalCommitMessageValidator _validator = new();
+
+    [Theory]
+    [InlineData("feat: add device discovery")]
+    [InlineData("fix: correct zigbee timeout")]
+    [InlineData("docs: document commit conventions")]
+    [InlineData("style: reformat with csharpier")]
+    [InlineData("refactor: extract command factory")]
+    [InlineData("perf: reduce allocation in mqtt handler")]
+    [InlineData("test: cover empty scope")]
+    [InlineData("build: bump dotnet sdk")]
+    [InlineData("ci: add release workflow")]
+    [InlineData("chore: update gitignore")]
+    [InlineData("revert: undo bad migration")]
+    public void WhenHeaderUsesAnAllowedTypeWithNoScopeThenIsValid(string message)
+    {
+        var result = _validator.Validate(message);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenHeaderHasScopeThenIsValid()
+    {
+        var result = _validator.Validate("fix(zigbee): handle disconnect race");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenHeaderHasBreakingChangeMarkerThenIsValid()
+    {
+        var result = _validator.Validate("feat(api)!: change device response shape");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenMessageHasBodyAfterHeaderThenOnlyHeaderIsValidated()
+    {
+        var result = _validator.Validate("feat: add device discovery\n\nSome longer explanation.");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenTypeIsNotAllowedThenIsInvalid()
+    {
+        var result = _validator.Validate("feature: add device discovery");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenTypeIsUppercaseThenIsInvalid()
+    {
+        var result = _validator.Validate("Feat: add device discovery");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenColonIsMissingThenIsInvalid()
+    {
+        var result = _validator.Validate("feat add device discovery");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenDescriptionIsMissingThenIsInvalid()
+    {
+        var result = _validator.Validate("feat:");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenDescriptionIsOnlyWhitespaceThenIsInvalid()
+    {
+        var result = _validator.Validate("feat:    ");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\n")]
+    public void WhenMessageIsEmptyThenIsInvalid(string message)
+    {
+        var result = _validator.Validate(message);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenInvalidThenErrorExplainsTheExpectedFormat()
+    {
+        var result = _validator.Validate("added device discovery");
+
+        Assert.False(result.IsValid);
+        Assert.Contains("type(scope): description", result.Error);
+        Assert.Contains("feat", result.Error);
+    }
+
+    [Fact]
+    public void WhenMessageIsGitGeneratedMergeCommitThenIsValid()
+    {
+        var result = _validator.Validate("Merge branch 'main' into feature/x");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void WhenMessageIsGitGeneratedRevertCommitThenIsValid()
+    {
+        var result = _validator.Validate("Revert \"feat: add device discovery\"\n\nThis reverts commit abc123.");
+
+        Assert.True(result.IsValid);
+    }
+}


### PR DESCRIPTION
## Summary
- Document a project-wide Conventional Commits convention in `CONTRIBUTING.md` (format, allowed types, and why — it drives the git-cliff-generated release notes in a sibling in-flight PR), with a pointer from `CLAUDE.md`.
- Enforce it mechanically with a new Husky.Net `commit-msg` hook (`.husky/commit-msg`), backed by a pure, unit-tested `ConventionalCommitMessageValidator` and a thin CLI command (`git validate-commit-message`) added to the existing `Haus.Utilities` CQRS-CLI tooling — no separate Node/commitlint toolchain.
- Re-scope the existing `format`/`CSharpier` pre-commit tasks into a `pre-commit` task-runner group (and update `.husky/pre-commit` to match) after confirming empirically that `dotnet husky run` with no `--group` flag runs *every* task regardless of group — without this, the new commit-msg task would also have fired (and failed) during ordinary pre-commit runs.
- Git-generated `Merge`/`Revert "..."` commit headers are exempted from validation.

## Test plan
- [x] `dotnet test tests/Haus.Utilities.Tests` — 82/82 passing, including 29 cases for the validator (valid/invalid types, scope, breaking-change marker with/without scope, missing description, empty message, leading blank lines, Merge/Revert bypass, uppercase-scope rejection).
- [x] `make test-unit` — full suite green aside from 3 pre-existing failures in `Haus.Web.Host.Tests.Application.ApplicationApiTests` caused by a missing `GITHUB_TOKEN` in this sandbox (unrelated to this change).
- [x] Real end-to-end proof via actual `git commit` invocations in the worktree:
  - A non-conventional message (`"this is not a conventional commit message"`) was rejected: the `commit-msg` hook exited 1 with the formatted error, and no commit was created.
  - Conventional messages (including an `--allow-empty` one) were accepted and committed normally.
- [x] Fresh-eyes review via `craft-code-reviewer` — one blocking style finding (null-forgiving operator) and three suggestions were addressed in a follow-up commit (`9a5e6e8`), driven by new failing tests first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)