### PR TITLE
Add git-cliff release notes; fix deprecated release-pipeline actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
         description: 'What kind of release is this?'
         required: true
         default: 'patch'
+permissions:
+  contents: write
 jobs:
   generate_release:
     name: Generate Release
@@ -26,26 +28,37 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v7
+        with:
+          # Full history + all tags: scripts/compute-next-version.sh needs every
+          # existing tag to find the latest one, and git-cliff needs the full
+          # commit history to diff against the previous tag.
+          fetch-depth: 0
 
       - name: Setup Machine
         uses: ./.github/actions/setup-machine
 
-      - name: Bump version and Push Tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          default_bump: ${{ github.event.inputs.version_bump || 'patch' }}
+          tool: git-cliff
+
+      - name: Compute Next Version
+        id: compute_version
+        run: |
+          ./scripts/compute-next-version.sh
+          echo "new_tag=$(cat next-version.txt)" >> "$GITHUB_OUTPUT"
+        env:
+          VERSION_BUMP: ${{ github.event.inputs.version_bump || 'patch' }}
 
       - name: Publish App
         run: make publish
         env:
-          VERSION: ${{ steps.tag_version.outputs.new_tag }}
+          VERSION: ${{ steps.compute_version.outputs.new_tag }}
 
       - name: Publish to Docker Hub
         run: make docker-publish
         env:
-          VERSION: ${{ steps.tag_version.outputs.new_tag }}
+          VERSION: ${{ steps.compute_version.outputs.new_tag }}
 
       # Runs after Docker Hub publish, since the packaged docker-compose.yml
       # pins this release's image tags and the install smoke test (inside
@@ -62,34 +75,17 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "asset_path=publish/installer/haus-app_${VERSION}_amd64.deb" >> "$GITHUB_OUTPUT"
         env:
-          VERSION: ${{ steps.tag_version.outputs.new_tag }}
+          VERSION: ${{ steps.compute_version.outputs.new_tag }}
+
+      - name: Generate Release Notes
+        run: ./scripts/generate-release-notes.sh "${{ steps.compute_version.outputs.new_tag }}" > release-notes.md
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
-
-      - name: Service Package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./publish/service_package.zip
-          asset_name: service_package.zip
-          asset_content_type: application/zip
-
-      - name: Ubuntu Package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.deb_package.outputs.asset_path }}
-          asset_name: haus-app_${{ steps.deb_package.outputs.version }}_amd64.deb
-          asset_content_type: application/vnd.debian.binary-package
+          tag_name: ${{ steps.compute_version.outputs.new_tag }}
+          name: Release ${{ steps.compute_version.outputs.new_tag }}
+          body_path: release-notes.md
+          files: |
+            ./publish/service_package.zip
+            ${{ steps.deb_package.outputs.asset_path }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ MQTT_TEST_CONTAINER := haus_mqtt_unit_tests
 MQTT_TEST_PORT := 21883
 
 .PHONY: build certs publish start stop watch web-host site-host zigbee-host \
-        test-unit test-acceptance docker-publish deb-package add-project migration
+        test-unit test-acceptance docker-publish deb-package add-project migration \
+        release-notes
 
 verify: build test-unit test-acceptance
 
@@ -77,3 +78,6 @@ add-project:
 
 migration:
 	./scripts/create-ef-migration.sh $(NAME)
+
+release-notes:
+	./scripts/generate-release-notes.sh $(TAG)

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,51 @@
+# git-cliff configuration for HAUS release notes.
+# Docs: https://git-cliff.org/docs/configuration
+# Generated via `make release-notes` locally, or `scripts/generate-release-notes.sh`
+# in the release pipeline (.github/workflows/release.yaml).
+
+[changelog]
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+render_always = true
+
+[git]
+# Commits are parsed for a conventional-commit type prefix (feat/fix/...),
+# but NOT filtered to only conventional commits: this repo's history
+# predates that convention (still being adopted separately -- see
+# docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md), so
+# `filter_unconventional = false` lets `commit_parsers` below fall back to
+# matching this repo's existing capitalized-imperative commit style
+# ("Add X", "Fix Y", "Rename Z") instead of dropping those commits entirely.
+conventional_commits = true
+filter_unconventional = false
+protect_breaking_commits = true
+# This repo's commits aren't conventional (no "type: subject" header), so
+# git-cliff has no header/body split to key off of and `commit.message`
+# would otherwise be the entire raw commit message. Release notes should
+# read as a scannable list, not reproduce every commit's full body, so
+# trim each message down to its first line.
+commit_preprocessors = [{ pattern = '(?s)\n.*', replace = "" }]
+commit_parsers = [
+    { message = "^(?i)fix", group = "Bug Fixes" },
+    { message = "^(?i)feat", group = "Features" },
+    { message = "^(?i)add", group = "Features" },
+    { message = "^(?i)(docs?|document)", group = "Documentation" },
+    { message = "^(?i)perf", group = "Performance" },
+    { message = "^(?i)(refactor|rename|extract|replace|restructure)", group = "Refactor" },
+    { message = "^(?i)style", group = "Styling" },
+    { message = "^(?i)test", group = "Testing" },
+    { message = "^(?i)revert", group = "Reverts" },
+    { message = "^(?i)(chore|ci|bump|update|merge|register|address)", group = "Miscellaneous Tasks" },
+    { message = ".*", group = "Other" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+topo_order = false
+sort_commits = "oldest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,11 +4,18 @@
 # in the release pipeline (.github/workflows/release.yaml).
 
 [changelog]
+# This repo's commits aren't conventional (no "type: subject" header), so
+# commit.message is the entire raw commit message, not just a summary
+# line. `body` truncates each message to its first line in the template
+# itself (not a [git] commit_preprocessor below) so the full raw message
+# -- including any "BREAKING CHANGE:" footer -- is still what
+# conventional_commits parses; a preprocessor would strip that footer
+# before protect_breaking_commits / commit.breaking ever saw it.
 body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
-- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}
 {% endfor %}
 {% endfor %}
 """
@@ -26,23 +33,17 @@ render_always = true
 conventional_commits = true
 filter_unconventional = false
 protect_breaking_commits = true
-# This repo's commits aren't conventional (no "type: subject" header), so
-# git-cliff has no header/body split to key off of and `commit.message`
-# would otherwise be the entire raw commit message. Release notes should
-# read as a scannable list, not reproduce every commit's full body, so
-# trim each message down to its first line.
-commit_preprocessors = [{ pattern = '(?s)\n.*', replace = "" }]
 commit_parsers = [
     { message = "^(?i)fix", group = "Bug Fixes" },
     { message = "^(?i)feat", group = "Features" },
-    { message = "^(?i)add", group = "Features" },
+    { message = "^(?i)add\\b", group = "Features" },
     { message = "^(?i)(docs?|document)", group = "Documentation" },
     { message = "^(?i)perf", group = "Performance" },
     { message = "^(?i)(refactor|rename|extract|replace|restructure)", group = "Refactor" },
     { message = "^(?i)style", group = "Styling" },
     { message = "^(?i)test", group = "Testing" },
     { message = "^(?i)revert", group = "Reverts" },
-    { message = "^(?i)(chore|ci|bump|update|merge|register|address)", group = "Miscellaneous Tasks" },
+    { message = "^(?i)(chore|build|ci|bump|update|merge|register|address)", group = "Miscellaneous Tasks" },
     { message = ".*", group = "Other" },
 ]
 filter_commits = false

--- a/docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md
+++ b/docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md
@@ -54,14 +54,18 @@ commit-message convention work lands — conventional-format commits already
 match the same parsers.
 
 `scripts/generate-release-notes.sh` wraps the `git-cliff` invocation
-(`--config cliff.toml --unreleased --strip header`, or `--tag <tag>
---unreleased` when a tag argument is given) so the exact same command runs
-from a developer's machine (`make release-notes`) and from CI — no
-CI-only templating logic to drift out of sync with what a human sees
-locally. `--unreleased` is used even in CI: the tag doesn't exist yet at
-notes-generation time (see stage ordering below), so `--tag <computed-tag>
---unreleased` asks git-cliff to label the pending commits with that name
-without requiring the tag object to already exist.
+(`--config cliff.toml --unreleased`, or `--tag <tag> --unreleased` when a
+tag argument is given) so the exact same command runs from a developer's
+machine (`make release-notes`) and from CI — no CI-only templating logic
+to drift out of sync with what a human sees locally. `--unreleased` is
+used even in CI: the tag doesn't exist yet at notes-generation time (see
+stage ordering below), so `--tag <computed-tag> --unreleased` asks
+git-cliff to label the pending commits with that name without requiring
+the tag object to already exist. `cliff.toml`'s `body` template
+deliberately omits the `## [version] - date` heading git-cliff's default
+template renders — GitHub's release page already shows the tag/name as
+its own title, so that heading would just be a duplicate directly above
+the categorized list.
 
 git-cliff itself isn't vendored or installed as a prerequisite for `make
 release-notes` — like `dotnet`/`docker`, it's assumed present locally
@@ -118,8 +122,8 @@ through.
 
 ## Evidence-of-done
 
-- `git-cliff --config cliff.toml --unreleased --strip header` run against
-  this repo's real history, output inspected for sane grouping.
+- `git-cliff --config cliff.toml --unreleased` run against this repo's
+  real history, output inspected for sane grouping.
 - `dotnet test tests/Haus.Utilities.Tests --filter FullyQualifiedName~SemVerBumper`
   green.
 - `actionlint .github/workflows/release.yaml` (or reasoning through each

--- a/docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md
+++ b/docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md
@@ -51,7 +51,10 @@ matches both real conventional prefixes (`feat`, `fix`, `docs`, ...) *and*
 this repo's existing capitalized-imperative style (`Add`, `Fix`, `Rename`,
 `Bump`, ...), so notes are useful now and get more precise for free once the
 commit-message convention work lands — conventional-format commits already
-match the same parsers.
+match the same parsers. The prefix set matches the 11 types locked by the
+sibling `polly/conventional-commits-convention` PR (`feat, fix, docs, style,
+refactor, perf, test, build, ci, chore, revert`), so nothing here needs to
+change once that PR merges.
 
 `scripts/generate-release-notes.sh` wraps the `git-cliff` invocation
 (`--config cliff.toml --unreleased`, or `--tag <tag> --unreleased` when a

--- a/docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md
+++ b/docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md
@@ -1,0 +1,126 @@
+# Pipeline design: git-cliff release notes + deprecated-action cleanup in release.yaml
+
+Targeted change to an existing pipeline (`.github/workflows/release.yaml`) —
+replaces three actions the real run
+https://github.com/bryceklinker/haus/actions/runs/31835249891 (job
+94880010990) flagged as forcing deprecated Node 20 / `set-output`: `actions/
+create-release@v1`, `actions/upload-release-asset@v1` (both archived), and
+`mathieudutour/github-tag-action@v6.2`. Adds git-cliff-generated release
+notes as a second, independent goal riding the same steps.
+
+## Artifact strategy
+
+No new artifact. `release-notes.md` is a build-time intermediate (Release
+step body input), not a published asset — it's regenerated every run from
+git history, so keeping it around after the job ends has no value. The two
+existing release assets (`service_package.zip`, the `.deb`) are unchanged;
+only the action that uploads them changes.
+
+## Version bump: manual input stays authoritative, no auto-bump from history
+
+`mathieudutour/github-tag-action` is removed outright rather than replaced
+1:1. Its `default_bump` was always a fallback to a workflow input humans
+already set explicitly (`version_bump: patch|minor|major`,
+`workflow_dispatch`) — its conventional-commit auto-detection added a second,
+usually-redundant path to the same decision.
+
+*Why not have git-cliff compute the bump instead* (`--bumped-version`,
+raised as an option): this repo's commit history is not yet conventional —
+`git log --oneline` shows `Add Ubuntu Package`, `Rename haus_sit compose
+service key`, `Bump Microsoft.NET.Test.Sdk` — so an auto-detected bump would
+be a guess dressed as a computation until the commit-message convention
+(tracked separately) lands and has actually been followed for a while.
+Keeping the explicit `version_bump` input is simpler and honest about who's
+deciding: a human, at `workflow_dispatch` time, same as today.
+
+The replacement is a small pure function — `SemVerBumper` in
+`Haus.Utilities` (mirrors the existing `DebComposeVersionPinner` /
+`packaging render-deb-compose` CLI-command pattern already in this project)
+— given the latest `vX.Y.Z` tag and a bump kind, returns the next tag.
+`scripts/compute-next-version.sh` finds the latest tag via
+`git tag --list 'v*' --sort=-v:refname` and invokes it. Pure, deterministic,
+easy to unit test — unlike the third-party action it replaces, which needed
+network calls and repo write access to test at all.
+
+## Release notes: git-cliff, generated the same way locally and in CI
+
+`cliff.toml` (repo root) configures `conventional_commits = true` but
+`filter_unconventional = false`: strict conventional-commit filtering would
+silently drop nearly this repo's entire history today. `commit_parsers`
+matches both real conventional prefixes (`feat`, `fix`, `docs`, ...) *and*
+this repo's existing capitalized-imperative style (`Add`, `Fix`, `Rename`,
+`Bump`, ...), so notes are useful now and get more precise for free once the
+commit-message convention work lands — conventional-format commits already
+match the same parsers.
+
+`scripts/generate-release-notes.sh` wraps the `git-cliff` invocation
+(`--config cliff.toml --unreleased --strip header`, or `--tag <tag>
+--unreleased` when a tag argument is given) so the exact same command runs
+from a developer's machine (`make release-notes`) and from CI — no
+CI-only templating logic to drift out of sync with what a human sees
+locally. `--unreleased` is used even in CI: the tag doesn't exist yet at
+notes-generation time (see stage ordering below), so `--tag <computed-tag>
+--unreleased` asks git-cliff to label the pending commits with that name
+without requiring the tag object to already exist.
+
+git-cliff itself isn't vendored or installed as a prerequisite for `make
+release-notes` — like `dotnet`/`docker`, it's assumed present locally
+(README documents `cargo install git-cliff` / `brew install git-cliff`). In
+CI it's installed via `taiki-e/install-action` (`tool: git-cliff`) — a
+composite (pure shell) action with no Node.js runtime at all, so it can't
+regress into the same deprecation warning this change is fixing.
+
+## Stage ordering
+
+```
+checkout → setup-machine → compute-next-version → make publish →
+make docker-publish → make deb-package → generate-release-notes →
+create_release (tag + notes + both assets)
+```
+
+*Why compute-next-version replaces bump-tag in the same slot:* every later
+step already depends on `VERSION` being known (image tags, `.deb` filename,
+compose pinning) — same dependency the old step satisfied, just without
+pushing a tag as a side effect.
+
+*Why generate-release-notes moves to just before create_release, not
+earlier:* it only needs git history, not the built artifacts, but placing
+it right before the step that consumes its output (`release-notes.md` as
+`body_path`) keeps the two adjacent and avoids the notes going stale
+relative to any commits landing on `main` while a long docker-publish/
+deb-package run is in flight (unlikely in a single job, but free to avoid).
+
+*Why the git tag is created by the Release step now, not a separate push:*
+`softprops/action-gh-release@v3` creates the tag itself if `tag_name`
+doesn't already exist on the remote. Folding tag-push into the same
+atomic action that creates the release removes a step and a window where a
+tag could exist with no corresponding release (e.g. if `create_release`
+failed after a manual push) — mirrors the existing gate philosophy in
+`2026-08-14-ubuntu-deb-package-pipeline.md`: nothing user-visible
+(tag or release) should exist for a build that didn't make it all the way
+through.
+
+## The action replacements
+
+- `actions/create-release@v1` + 2x `actions/upload-release-asset@v1`
+  (archived, `node20`) → single `softprops/action-gh-release@v3`
+  (`node24`, actively maintained, ~last release 2026-07). One step creates
+  the release, tags it, and uploads both assets via `files:`.
+- `mathieudutour/github-tag-action@v6.2` (`node20`, and its `set-output`
+  usage was the source of the 5x deprecation warnings) → removed; replaced
+  by the `SemVerBumper`/`compute-next-version.sh` pair above, which use
+  `$GITHUB_OUTPUT` (the current, non-deprecated mechanism) directly in the
+  workflow step, not inside a third-party action.
+- Added `permissions: contents: write` at job level: `softprops/
+  action-gh-release` needs to create the tag and release; made explicit
+  rather than relying on the default token's implicit permissions, which
+  are read-only on repos with restrictive defaults.
+
+## Evidence-of-done
+
+- `git-cliff --config cliff.toml --unreleased --strip header` run against
+  this repo's real history, output inspected for sane grouping.
+- `dotnet test tests/Haus.Utilities.Tests --filter FullyQualifiedName~SemVerBumper`
+  green.
+- `actionlint .github/workflows/release.yaml` (or reasoning through each
+  replaced action's `runs.using`) shows no Node 20 / `set-output` warnings.

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,10 @@ make test-acceptance
 
 # Run build, unit tests, and acceptance tests
 make verify
+
+# Preview release notes for the commits made since the last tag
+# (requires git-cliff: https://git-cliff.org/docs/installation)
+make release-notes
 ```
 
 # Environment Variables

--- a/scripts/compute-next-version.sh
+++ b/scripts/compute-next-version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+
+# CURRENT_VERSION is intentionally re-derived from git tags here rather than
+# trusted from the caller's environment: the release workflow's only source
+# of truth for "what was the last release" is the tag history itself.
+CURRENT_VERSION=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+export CURRENT_VERSION
+export VERSION_BUMP="${VERSION_BUMP:-patch}"
+
+dotnet run --project src/Haus.Utilities -- release bump-version

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+
+# Usage: ./scripts/generate-release-notes.sh [tag]
+#
+# With no argument, previews notes for the commits made since the last tag
+# (handy for a developer checking what a release would say before cutting
+# one). With a tag argument, labels those same pending commits with that
+# tag name -- used by the release pipeline, which generates notes for the
+# version scripts/compute-next-version.sh just computed before that tag
+# actually exists (see docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md).
+TAG="${1:-}"
+
+if [ -n "${TAG}" ]; then
+  git-cliff --config cliff.toml --tag "${TAG}" --unreleased
+else
+  git-cliff --config cliff.toml --unreleased
+fi

--- a/src/Haus.Utilities/Release/Commands/BumpVersionCommandHandler.cs
+++ b/src/Haus.Utilities/Release/Commands/BumpVersionCommandHandler.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Cqrs.Commands;
+using Haus.Utilities.Common.Cli;
+using Microsoft.Extensions.Logging;
+
+namespace Haus.Utilities.Release.Commands;
+
+[Command("release", "bump-version")]
+public record BumpVersionCommand : ICommand;
+
+public class BumpVersionCommandHandler(ISemVerBumper bumper, ILogger<BumpVersionCommandHandler> logger)
+    : ICommandHandler<BumpVersionCommand>
+{
+    // Logging goes to the console (see HausLogger.ConfigureConsoleOnly), so the
+    // computed version is written to a file rather than stdout -- scripts that
+    // capture "the next version" would otherwise have to filter log lines out
+    // of their own output.
+    private static readonly string OutputPath =
+        Environment.GetEnvironmentVariable("NEXT_VERSION_FILE") ?? "next-version.txt";
+
+    public async Task Handle(BumpVersionCommand request, CancellationToken cancellationToken)
+    {
+        var currentVersion = Environment.GetEnvironmentVariable("CURRENT_VERSION") ?? string.Empty;
+        var versionBump = Environment.GetEnvironmentVariable("VERSION_BUMP") ?? "patch";
+
+        var nextVersion = bumper.Bump(currentVersion, versionBump);
+        logger.LogInformation(
+            "Bumping {CurrentVersion} ({BumpKind}) -> {NextVersion}",
+            currentVersion,
+            versionBump,
+            nextVersion
+        );
+
+        await File.WriteAllTextAsync(OutputPath, nextVersion, cancellationToken);
+    }
+}

--- a/src/Haus.Utilities/Release/SemVerBumper.cs
+++ b/src/Haus.Utilities/Release/SemVerBumper.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Haus.Utilities.Release;
+
+public interface ISemVerBumper
+{
+    string Bump(string currentVersion, string bumpKind);
+}
+
+public partial class SemVerBumper : ISemVerBumper
+{
+    public string Bump(string currentVersion, string bumpKind)
+    {
+        var (major, minor, patch) = Parse(currentVersion);
+        return BumpKindOf(bumpKind) switch
+        {
+            "major" => $"v{major + 1}.0.0",
+            "minor" => $"v{major}.{minor + 1}.0",
+            "patch" => $"v{major}.{minor}.{patch + 1}",
+            _ => throw new ArgumentException($"Unknown bump kind '{bumpKind}'", nameof(bumpKind)),
+        };
+    }
+
+    private static string BumpKindOf(string bumpKind)
+    {
+        var normalized = bumpKind.Trim().ToLowerInvariant();
+        return normalized is "major" or "minor" or "patch"
+            ? normalized
+            : throw new ArgumentException($"Unknown bump kind '{bumpKind}'", nameof(bumpKind));
+    }
+
+    private static (int Major, int Minor, int Patch) Parse(string currentVersion)
+    {
+        if (string.IsNullOrWhiteSpace(currentVersion))
+            return (0, 0, 0);
+
+        var match = VersionPattern().Match(currentVersion.Trim());
+        if (!match.Success)
+            throw new FormatException($"'{currentVersion}' is not a valid vX.Y.Z version");
+
+        return (
+            int.Parse(match.Groups["major"].Value),
+            int.Parse(match.Groups["minor"].Value),
+            int.Parse(match.Groups["patch"].Value)
+        );
+    }
+
+    [GeneratedRegex(@"^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$")]
+    private static partial Regex VersionPattern();
+}

--- a/src/Haus.Utilities/Release/SemVerBumper.cs
+++ b/src/Haus.Utilities/Release/SemVerBumper.cs
@@ -13,21 +13,13 @@ public partial class SemVerBumper : ISemVerBumper
     public string Bump(string currentVersion, string bumpKind)
     {
         var (major, minor, patch) = Parse(currentVersion);
-        return BumpKindOf(bumpKind) switch
+        return bumpKind.Trim().ToLowerInvariant() switch
         {
             "major" => $"v{major + 1}.0.0",
             "minor" => $"v{major}.{minor + 1}.0",
             "patch" => $"v{major}.{minor}.{patch + 1}",
             _ => throw new ArgumentException($"Unknown bump kind '{bumpKind}'", nameof(bumpKind)),
         };
-    }
-
-    private static string BumpKindOf(string bumpKind)
-    {
-        var normalized = bumpKind.Trim().ToLowerInvariant();
-        return normalized is "major" or "minor" or "patch"
-            ? normalized
-            : throw new ArgumentException($"Unknown bump kind '{bumpKind}'", nameof(bumpKind));
     }
 
     private static (int Major, int Minor, int Patch) Parse(string currentVersion)

--- a/src/Haus.Utilities/ServiceCollectionExtensions.cs
+++ b/src/Haus.Utilities/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Haus.Hosting;
 using Haus.Utilities.Common.Cli;
 using Haus.Utilities.Packaging;
+using Haus.Utilities.Release;
 using Haus.Utilities.TypeScript.GenerateModels;
 using Haus.Utilities.Zigbee2Mqtt.GenerateDefaultDeviceTypeOptions;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IDeviceTypeOptionsParser, DeviceTypeOptionsParser>()
             .AddTransient<IDeviceTypeOptionsMerger, DeviceTypeOptionsMerger>()
             .AddTransient<IDebComposeVersionPinner, DebComposeVersionPinner>()
+            .AddTransient<ISemVerBumper, SemVerBumper>()
             .AddSingleton<ICommandFactory, CommandFactory>();
     }
 }

--- a/tests/Haus.Utilities.Tests/Release/SemVerBumperTests.cs
+++ b/tests/Haus.Utilities.Tests/Release/SemVerBumperTests.cs
@@ -1,0 +1,50 @@
+using System;
+using Haus.Utilities.Release;
+using Xunit;
+
+namespace Haus.Utilities.Tests.Release;
+
+public class SemVerBumperTests
+{
+    private readonly SemVerBumper _bumper = new();
+
+    [Theory]
+    [InlineData("v0.9.10", "patch", "v0.9.11")]
+    [InlineData("v0.9.10", "minor", "v0.10.0")]
+    [InlineData("v0.9.10", "major", "v1.0.0")]
+    [InlineData("v1.2.3", "PATCH", "v1.2.4")]
+    [InlineData("0.9.10", "patch", "v0.9.11")]
+    public void WhenCurrentVersionIsValidThenBumpsAccordingToKind(
+        string currentVersion,
+        string bumpKind,
+        string expected
+    )
+    {
+        var next = _bumper.Bump(currentVersion, bumpKind);
+
+        Assert.Equal(expected, next);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhenCurrentVersionIsMissingThenBumpsFromZero(string? currentVersion)
+    {
+        var next = _bumper.Bump(currentVersion!, "patch");
+
+        Assert.Equal("v0.0.1", next);
+    }
+
+    [Fact]
+    public void WhenBumpKindIsUnknownThenThrows()
+    {
+        Assert.Throws<ArgumentException>(() => _bumper.Bump("v0.9.10", "sideways"));
+    }
+
+    [Fact]
+    public void WhenCurrentVersionIsMalformedThenThrows()
+    {
+        Assert.Throws<FormatException>(() => _bumper.Bump("v1.2", "patch"));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes real GitHub Actions deprecation warnings from an actual run: `actions/create-release@v1` and `actions/upload-release-asset@v1` (both archived, forced onto Node 20) are replaced with a single `softprops/action-gh-release@v3` step (Node 24); `mathieudutour/github-tag-action@v6.2` (Node 20, source of 5x `set-output`-deprecated warnings) is removed outright.
- The removed tag-action's version-bump responsibility is replaced by a small pure `SemVerBumper` (`src/Haus.Utilities/Release/SemVerBumper.cs`, TDD'd), exposed as a CLI command (`release bump-version`, mirrors the existing `packaging render-deb-compose` pattern) and driven by `scripts/compute-next-version.sh`. The workflow's existing manual `version_bump` input stays authoritative — see the design note for why.
- Adds git-cliff-based release notes: `cliff.toml` groups this repo's mixed commit history (conventional prefixes where present, falling back to its existing capitalized-imperative style otherwise), and `scripts/generate-release-notes.sh` / `make release-notes` run the exact same command locally and in CI.
- Adds `taiki-e/install-action` (pure shell, no Node) to install `git-cliff` in CI, and explicit `permissions: contents: write` since `softprops/action-gh-release` needs to create the tag.

Design rationale: `docs/craft/design/2026-08-14-gitcliff-release-notes-pipeline.md`.

## Test plan
- [x] `dotnet test tests/Haus.Utilities.Tests` — 63/63 passing (10 new `SemVerBumper` tests)
- [x] Full non-acceptance unit test suite (656 tests across all projects) green after merging up-to-date `main`
- [x] `git-cliff --config cliff.toml` run against real repo history and a throwaway repo with a `BREAKING CHANGE:` footer commit, output inspected for correct grouping/truncation
- [x] `actionlint .github/workflows/release.yaml` — only the pre-existing, out-of-scope `is_release` warning remains (present on `main` before this change)
- [x] `release bump-version` CLI command run end-to-end with explicit and default env vars
- [x] Fresh-eyes review via `craft-code-reviewer` subagent; all findings addressed (parser-shadowing fix, moved truncation out of a commit-preprocessor to preserve `BREAKING CHANGE:` footer detection, dead-code removal, added the `build` commit type to match the sibling conventional-commits PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)