### PR TITLE
build: dependency maintenance (dotnet tools + NuGet)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -45,7 +45,7 @@
       "rollForward": false
     },
     "powershell": {
-      "version": "7.6.4",
+      "version": "7.6.5",
       "commands": [
         "pwsh"
       ],

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,7 +8,7 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Haus.Testing.Support' AND '$(MSBuildProjectName)' != 'Haus.Acceptance.Tests'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Routine dependency maintenance — no product behavior changes.

Full survey covered: NuGet packages across `Haus.slnx` (`dotnet outdated`), local `dotnet tool restore` tools (`.config/dotnet-tools.json`), npm/yarn (none exist in this repo), and `global.json`'s pinned SDK (already current, left untouched).

Only two things were actually behind:

| Package | Old | New | Type |
|---|---|---|---|
| `powershell` (dotnet tool, `.config/dotnet-tools.json`) | 7.6.4 | 7.6.5 | patch |
| `xunit.runner.visualstudio` (`tests/Directory.Build.props`, shared by all unit test projects) | 3.1.5 | 4.0.0 | major |

Everything else (Microsoft.* packages pinned via `$(MicrosoftPackageVersion)` in `Directory.Build.props`, xunit, coverlet, MudBlazor, Polly, Serilog.AspNetCore, Octokit, NUnit/Playwright for acceptance tests, and the other dotnet tools — reportgenerator, coverlet.console, dotnet-ef, csharpier, husky, dotnet-outdated-tool) is already at latest stable. `dotnet-ef`'s only newer release is a `11.0.0-preview` prerelease, which was skipped per the "avoid prerelease unless already on one" rule.

### xunit.runner.visualstudio 3.1.5 → 4.0.0 (major)

Read the [4.0.0 release notes](https://xunit.net/releases/visualstudio/4.0.0): it adds xUnit.net v3 / Native AOT test project support and a shutdown message-ordering fix; nothing in the notes indicated a breaking change for xUnit v2 projects (this repo is still on `xunit` 2.9.3). Applied it and ran the full non-acceptance test suite before/after — identical pass/fail results, so it's safe.

## Gates run

- `dotnet tool restore` — succeeded with the new `powershell` version.
- `dotnet restore` on the full solution — succeeded after the `xunit.runner.visualstudio` bump.
- `dotnet csharpier check .` — clean, no formatting drift.
- `make build` — all projects build successfully **except** `Haus.Acceptance.Tests`, which fails during its `InstallBrowsers` post-build step (`playwright.ps1 install --with-deps` needs `sudo`, and this sandbox has no interactive terminal for that). Verified this failure is **pre-existing** and unrelated to this PR by reproducing it identically on an unmodified checkout (`git stash` + rebuild).
- `make test-unit` (real gate, boots a disposable mosquitto container via Docker as the Makefile does) — ran to completion. All projects pass except 3 pre-existing failures in `Haus.Web.Host.Tests.Application.ApplicationApiTests` (`WhenGettingLatestPackagesThenReturnsLatestPackagesFromGitHub`, `WhenDownloadingPackageThenReturnsDownloadablePackage`, `WhenGettingLatestVersionThenReturnsLatestReleaseOnGithub`) — these hit the real GitHub API and 500 because no `GITHUB_TOKEN`/network access is available in this environment. Verified identical failures on an unmodified checkout, so this is a pre-existing environment gap, not a regression from these bumps.
- `make test-acceptance` — not run; requires the full Docker Compose stack plus the same Playwright browser install that's blocked in this sandbox.

## Skipped

Nothing else needed a version bump — everything besides the two packages above was already on latest stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)