### PR TITLE
fix(site): resolve API base URL from the browser's location

### DIFF
--- a/src/Haus.Site.Host/Configuration/ApiBaseUrlResolver.cs
+++ b/src/Haus.Site.Host/Configuration/ApiBaseUrlResolver.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Haus.Site.Host.Configuration;
+
+public static class ApiBaseUrlResolver
+{
+    public static string Resolve(string configuredBaseUrl, string hostEnvironmentBaseAddress)
+    {
+        var configured = new Uri(configuredBaseUrl);
+        var browserHost = new Uri(hostEnvironmentBaseAddress).Host;
+        return new UriBuilder(configured) { Host = browserHost }.Uri.GetLeftPart(UriPartial.Authority);
+    }
+}

--- a/src/Haus.Site.Host/Program.cs
+++ b/src/Haus.Site.Host/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
-builder.Services.AddHausSiteServices(builder.Configuration);
+builder.Services.AddHausSiteServices(builder.Configuration, builder.HostEnvironment.BaseAddress);
 builder.RootComponents.AddHausSiteComponents();
 
 var host = builder.Build();

--- a/src/Haus.Site.Host/ServiceCollectionExtensions.cs
+++ b/src/Haus.Site.Host/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Haus.Api.Client;
+using Haus.Site.Host.Configuration;
 using Haus.Site.Host.Shared.Realtime;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -11,17 +12,23 @@ namespace Haus.Site.Host;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddHausSiteServices(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddHausSiteServices(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string hostEnvironmentBaseAddress
+    )
     {
-        var apiUrl = configuration.GetValue<string>("Api:BaseUrl");
+        var configuredApiUrl = configuration.GetValue<string>("Api:BaseUrl");
         var authDomain = configuration.GetValue<string>("Auth:Domain");
         var authClientId = configuration.GetValue<string>("Auth:ClientId");
         var authAudience = configuration.GetValue<string>("Auth:Audience");
 
-        ArgumentException.ThrowIfNullOrEmpty(apiUrl, nameof(apiUrl));
+        ArgumentException.ThrowIfNullOrEmpty(configuredApiUrl, nameof(configuredApiUrl));
         ArgumentException.ThrowIfNullOrEmpty(authDomain, nameof(authDomain));
         ArgumentException.ThrowIfNullOrEmpty(authClientId, nameof(authClientId));
         ArgumentException.ThrowIfNullOrEmpty(authAudience, nameof(authAudience));
+
+        var apiUrl = ApiBaseUrlResolver.Resolve(configuredApiUrl, hostEnvironmentBaseAddress);
 
         services.AddMudServices();
         services.AddScoped<AuthorizationMessageHandler>(sp =>

--- a/tests/Haus.Site.Host.Tests/Configuration/ApiBaseUrlResolverTests.cs
+++ b/tests/Haus.Site.Host.Tests/Configuration/ApiBaseUrlResolverTests.cs
@@ -1,0 +1,22 @@
+using Haus.Site.Host.Configuration;
+
+namespace Haus.Site.Host.Tests.Configuration;
+
+public class ApiBaseUrlResolverTests
+{
+    [Fact]
+    public void WhenBrowserHostDiffersFromConfiguredHostThenResolvesUsingBrowserHost()
+    {
+        var resolved = ApiBaseUrlResolver.Resolve("https://localhost:5001", "https://192.168.1.50:5003/");
+
+        Assert.Equal("https://192.168.1.50:5001", resolved);
+    }
+
+    [Fact]
+    public void WhenBrowserHostMatchesConfiguredHostThenResolvedUrlIsUnchanged()
+    {
+        var resolved = ApiBaseUrlResolver.Resolve("https://localhost:5001", "https://localhost:5003/");
+
+        Assert.Equal("https://localhost:5001", resolved);
+    }
+}

--- a/tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Haus.Api.Client.Options;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -19,6 +26,24 @@ public class ServiceCollectionExtensionsTests
         Assert.Equal("https://192.168.1.50:5001", settings.BaseUrl);
     }
 
+    [Fact]
+    public async Task WhenRequestTargetsResolvedApiHostThenAuthorizationHeaderIsAttached()
+    {
+        var services = new ServiceCollection();
+        services.AddHausSiteServices(BuildConfiguration(), "https://192.168.1.50:5003/");
+        services.AddSingleton<NavigationManager>(new StubNavigationManager("https://192.168.1.50:5003/"));
+        services.AddSingleton<IAccessTokenProvider, StubAccessTokenProvider>();
+        var provider = services.BuildServiceProvider();
+        var handler = provider.GetRequiredService<AuthorizationMessageHandler>();
+        var capture = new CapturingHandler();
+        handler.InnerHandler = capture;
+        using var client = new HttpClient(handler);
+
+        await client.GetAsync("https://192.168.1.50:5001/api/devices");
+
+        Assert.NotNull(capture.LastRequest?.Headers.Authorization);
+    }
+
     private static IConfiguration BuildConfiguration()
     {
         return new ConfigurationBuilder()
@@ -32,5 +57,40 @@ public class ServiceCollectionExtensionsTests
                 }
             )
             .Build();
+    }
+
+    private sealed class StubNavigationManager : NavigationManager
+    {
+        public StubNavigationManager(string baseUri) => Initialize(baseUri, baseUri);
+    }
+
+    private sealed class StubAccessTokenProvider : IAccessTokenProvider
+    {
+        public ValueTask<AccessTokenResult> RequestAccessToken() => RequestAccessToken(new AccessTokenRequestOptions());
+
+        public ValueTask<AccessTokenResult> RequestAccessToken(AccessTokenRequestOptions options)
+        {
+            var token = new AccessToken
+            {
+                Value = "test-token",
+                Expires = DateTimeOffset.UtcNow.AddHours(1),
+                GrantedScopes = [],
+            };
+            return ValueTask.FromResult(new AccessTokenResult(AccessTokenResultStatus.Success, token, null, null));
+        }
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
     }
 }

--- a/tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Haus.Api.Client.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Haus.Site.Host.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void WhenBrowserHostDiffersFromConfiguredApiHostThenRegisteredApiClientUsesBrowserHost()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHausSiteServices(BuildConfiguration(), "https://192.168.1.50:5003/");
+
+        var settings = services.BuildServiceProvider().GetRequiredService<IOptions<HausApiClientSettings>>().Value;
+        Assert.Equal("https://192.168.1.50:5001", settings.BaseUrl);
+    }
+
+    private static IConfiguration BuildConfiguration()
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Api:BaseUrl"] = "https://localhost:5001",
+                    ["Auth:Domain"] = "haus-app.us.auth0.com",
+                    ["Auth:ClientId"] = "client-id",
+                    ["Auth:Audience"] = "https://haus-portal-api.com",
+                }
+            )
+            .Build();
+    }
+}


### PR DESCRIPTION
## Summary
- Haus.Site.Host (the Blazor WASM app) baked `Api:BaseUrl` from `wwwroot/appsettings.json` verbatim into the API client, hardcoding the host as `localhost`. Deployed and accessed from a machine other than the one running Haus.Web.Host, `localhost` resolves to the browser's own machine, not the API — surfacing as connection/CORS-style failures. Server-side CORS is already `AllowAnyOrigin()`, so that wasn't the fix point.
- In every deployment topology in this repo (docker-compose.yml prod, docker-compose.local.yml local/acceptance, `make watch` dev), the site and API are always co-located on the same host at different ports/schemes per environment. So the fix keeps the configured scheme+port from `Api:BaseUrl` (still supplied per-environment via `appsettings.{Environment}.json`, baked at build time as before) but resolves the **host** from the browser's actual current location (`WebAssemblyHostBuilder.HostEnvironment.BaseAddress`), available before the DI container is built.
- New pure `ApiBaseUrlResolver.Resolve(configuredBaseUrl, hostEnvironmentBaseAddress)` drives both the API client's `BaseUrl` and the `AuthorizationMessageHandler`'s authorized origin, so bearer tokens are attached (or withheld) based on the resolved origin, not the raw configured one.

## Files changed
- `src/Haus.Site.Host/Configuration/ApiBaseUrlResolver.cs` (new)
- `src/Haus.Site.Host/ServiceCollectionExtensions.cs`
- `src/Haus.Site.Host/Program.cs`
- `tests/Haus.Site.Host.Tests/Configuration/ApiBaseUrlResolverTests.cs` (new)
- `tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs` (new)

## Test plan
- [x] `ApiBaseUrlResolverTests` — different browser host resolves using the browser's host; same browser host resolves unchanged (locks in `make watch`/`make start` behavior).
- [x] `ServiceCollectionExtensionsTests` — the DI-registered API client's `BaseUrl` uses the resolved URL; the `AuthorizationMessageHandler` attaches `Authorization` only for requests to the resolved origin (proven red first by temporarily reverting the wiring to the raw configured URL, then green again).
- [x] Manual check: `ApiBaseUrlResolver.Resolve` against the exact values baked into `appsettings.json` (prod), `appsettings.Acceptance.json`, and dev launch settings, for both a cross-machine browser host and a same-machine one — dev/acceptance resolve unchanged, cross-machine now resolves to the browser's real host.
- [x] `Haus.Site.Host.Tests` full project: 105/105 passing.
- [x] `Haus.Core.Models.Tests`, `Haus.Core.Tests`, `Haus.Cqrs.Tests`, `Haus.Utilities.Tests`, `Haus.Mqtt.Client.Tests`, `Haus.Zigbee.Tests`, `Haus.Zigbee.Simulator.Tests`, `Haus.Zigbee.Host.Tests`: all green.
- [ ] `Haus.Web.Host.Tests`: 45/48 pass; the 3 failures (`ApplicationApiTests`, real calls to GitHub's API) are pre-existing and reproduce identically on `main` unmodified — this sandbox has no `GITHUB_TOKEN`/GitHub network egress. Unrelated to this change (Web.Host wasn't touched).
- [ ] `make test-acceptance` not run — this sandbox can't install Playwright's browsers (`sudo` requires a terminal), a pre-existing environment limitation unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)