### PR TITLE
fix(site): route SignalR hub connection through resolved API URL

### DIFF
--- a/src/Haus.Site.Host/ServiceCollectionExtensions.cs
+++ b/src/Haus.Site.Host/ServiceCollectionExtensions.cs
@@ -57,7 +57,10 @@ public static class ServiceCollectionExtensions
                 opts.ProviderOptions.AdditionalProviderParameters.Add("audience", authAudience);
             });
 
-        services.AddScoped<IRealtimeDataFactory, SignalRRealtimeDataFactory>();
+        services.AddScoped<IRealtimeDataFactory>(sp => new SignalRRealtimeDataFactory(
+            apiUrl,
+            sp.GetRequiredService<IAccessTokenProvider>()
+        ));
         return services;
     }
 }

--- a/src/Haus.Site.Host/Shared/Realtime/SignalRRealtimeDataFactory.cs
+++ b/src/Haus.Site.Host/Shared/Realtime/SignalRRealtimeDataFactory.cs
@@ -1,22 +1,17 @@
-using System;
 using System.Threading.Tasks;
 using Haus.Core.Models;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Haus.Site.Host.Shared.Realtime;
 
-public class SignalRRealtimeDataFactory(IConfiguration config, IAccessTokenProvider tokenProvider)
-    : IRealtimeDataFactory
+public class SignalRRealtimeDataFactory(string apiUrl, IAccessTokenProvider tokenProvider) : IRealtimeDataFactory
 {
-    private string? ApiUrl => config.GetValue<string>("Api:BaseUrl");
+    public string ApiUrl { get; } = apiUrl;
 
     public Task<IRealtimeDataSubscriber> CreateSubscriber(string source)
     {
-        ArgumentException.ThrowIfNullOrEmpty(ApiUrl);
-
         var connection = new HubConnectionBuilder()
             .WithAutomaticReconnect()
             .AddJsonProtocol(opts =>

--- a/tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Haus.Site.Host.Tests/ServiceCollectionExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Api.Client.Options;
+using Haus.Site.Host.Shared.Realtime;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.Configuration;
@@ -24,6 +25,19 @@ public class ServiceCollectionExtensionsTests
 
         var settings = services.BuildServiceProvider().GetRequiredService<IOptions<HausApiClientSettings>>().Value;
         Assert.Equal("https://192.168.1.50:5001", settings.BaseUrl);
+    }
+
+    [Fact]
+    public void WhenBrowserHostDiffersFromConfiguredApiHostThenRegisteredRealtimeFactoryUsesBrowserHost()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHausSiteServices(BuildConfiguration(), "https://192.168.1.50:5003/");
+        services.AddSingleton<IAccessTokenProvider, StubAccessTokenProvider>();
+
+        var factory = (SignalRRealtimeDataFactory)
+            services.BuildServiceProvider().GetRequiredService<IRealtimeDataFactory>();
+        Assert.Equal("https://192.168.1.50:5001", factory.ApiUrl);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- The SignalR realtime data factory built its hub URL from the raw configured `Api:BaseUrl` instead of the browser-resolved value already used by the HTTP client and auth handler (introduced in #29).
- When the site was served from a machine other than `localhost` (e.g. accessed over the LAN), SignalR negotiate calls still targeted `localhost`, causing a same-origin/CORS failure and breaking realtime updates.
- Routes the hub connection through the same resolved API URL used elsewhere, so negotiate calls target the correct host.

## Context
This commit (`e858378`) was originally pushed to the `fix/wasm-api-base-url` branch as a follow-up to the API-base-URL-resolver work, but the human merged that branch's base PR (#29) before this commit landed, leaving it orphaned on the remote with no reachable PR. This PR re-bases it cleanly onto current `main` via cherry-pick — no conflicts, since the base resolver work is already merged.

## Test plan
- [x] `dotnet build tests/Haus.Site.Host.Tests` — succeeds
- [x] `dotnet test tests/Haus.Site.Host.Tests --no-build` — 106/106 passed
- [x] `make test-unit` — all suites pass except pre-existing/unrelated failures in `Haus.Web.Host.Tests.Application.ApplicationApiTests` (3 tests hitting the real GitHub API), which fail in this sandbox because `GITHUB_TOKEN` isn't set; unrelated to this change (touches only `Haus.Site.Host`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)