### PR TITLE
fix(zigbee): make ConBee serial device path configurable and auto-detected

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,11 @@ services:
     image: bryceklinker/personal:haus-zigbee-latest
     environment:
       - "Haus__Server=mqtt://haus_mqtt:1883"
-      - "Zigbee__SerialPort=/dev/ttyACM0"
+      - "Zigbee__SerialPort=${ZIGBEE_SERIAL_PORT:-/dev/ttyACM0}"
     links:
       - haus_mqtt
     devices:
-      - /dev/ttyACM0:/dev/ttyACM0
+      - "${ZIGBEE_SERIAL_PORT:-/dev/ttyACM0}:${ZIGBEE_SERIAL_PORT:-/dev/ttyACM0}"
     volumes:
       - ./haus_zigbee:/app/data
       - ./haus_zigbee/logs:/app/haus-logs

--- a/packaging/deb/DEBIAN/postinst
+++ b/packaging/deb/DEBIAN/postinst
@@ -4,6 +4,47 @@ set -e
 CONFIG_DIR="/etc/haus"
 DATA_DIR="/var/lib/haus/data"
 CERT_PASSWORD="password"
+ENV_FILE="$CONFIG_DIR/.env"
+
+# Prefers the ConBee II's stable /dev/serial/by-id symlink (survives reboots
+# and replugs) over a bare ttyACM/ttyUSB scan, since ttyACM/ttyUSB enumeration
+# order is not stable across reboots/replugs. Falls back to the first
+# ttyACM*/ttyUSB* node only when no by-id symlink is present at all.
+detect_zigbee_serial_port() {
+  for by_id_path in /dev/serial/by-id/*; do
+    [ -e "$by_id_path" ] || continue
+    lower_name=$(printf '%s' "$by_id_path" | tr 'A-Z' 'a-z')
+    case "$lower_name" in
+      *conbee*|*dresden*)
+        echo "$by_id_path"
+        return 0
+        ;;
+    esac
+  done
+
+  for tty_path in /dev/ttyACM* /dev/ttyUSB*; do
+    [ -e "$tty_path" ] || continue
+    echo "$tty_path"
+    return 0
+  done
+
+  return 1
+}
+
+# Best-effort, mirroring the haus_zigbee restart below: a missing/undetectable
+# dongle at install time must not fail postinst. Never overwrites an existing
+# ZIGBEE_SERIAL_PORT so an operator's manual override in the .env file (or a
+# previous run's detection) always wins over rescanning.
+set_detected_zigbee_serial_port() {
+  if [ -f "$ENV_FILE" ] && grep -q '^ZIGBEE_SERIAL_PORT=' "$ENV_FILE"; then
+    return 0
+  fi
+
+  detected_port=$(detect_zigbee_serial_port) || return 0
+
+  touch "$ENV_FILE"
+  echo "ZIGBEE_SERIAL_PORT=${detected_port}" >> "$ENV_FILE"
+}
 
 case "$1" in
   configure)
@@ -11,6 +52,8 @@ case "$1" in
              "$DATA_DIR/haus_zigbee/logs" \
              "$DATA_DIR/haus_mqtt/data" \
              "$DATA_DIR/haus_mqtt/log"
+
+    set_detected_zigbee_serial_port || true
 
     # openssl only, deliberately -- unlike scripts/linux-install.sh's
     # `dotnet dev-certs` step, this package must not require the .NET SDK

--- a/packaging/deb/etc/haus/docker-compose.yml.template
+++ b/packaging/deb/etc/haus/docker-compose.yml.template
@@ -24,11 +24,11 @@ services:
     image: bryceklinker/personal:haus-zigbee-latest
     environment:
       - "Haus__Server=mqtt://haus_mqtt:1883"
-      - "Zigbee__SerialPort=/dev/ttyACM0"
+      - "Zigbee__SerialPort=${ZIGBEE_SERIAL_PORT:-/dev/ttyACM0}"
     links:
       - haus_mqtt
     devices:
-      - /dev/ttyACM0:/dev/ttyACM0
+      - "${ZIGBEE_SERIAL_PORT:-/dev/ttyACM0}:${ZIGBEE_SERIAL_PORT:-/dev/ttyACM0}"
     volumes:
       - /var/lib/haus/data/haus_zigbee:/app/data
       - /var/lib/haus/data/haus_zigbee/logs:/app/haus-logs

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,16 @@ may change in the future.
 Zigbee is an open protocol that various manufacturers are using in their "smart" devices. The current version is
 targeting support for many Zigbee devices.
 
+The Zigbee coordinator (e.g. a ConBee II dongle) is exposed to the `haus_zigbee` container via the
+`ZIGBEE_SERIAL_PORT` environment variable, read by both `docker-compose.yml` and
+`packaging/deb/etc/haus/docker-compose.yml.template` (default: `/dev/ttyACM0`). ttyACM/ttyUSB enumeration is not
+stable across reboots/replugs, so if the dongle isn't at the default path, set `ZIGBEE_SERIAL_PORT` in a `.env` file
+next to the compose file (`/etc/haus/.env` for the `.deb` install) -- docker compose loads it automatically. Prefer
+the dongle's stable `/dev/serial/by-id/...` symlink over a raw `/dev/ttyACMx` node, since that path doesn't change
+across replugs. On `.deb` installs, `postinst` auto-detects the dongle and writes `ZIGBEE_SERIAL_PORT` into
+`/etc/haus/.env` at install/upgrade time when it isn't already set there -- it never overwrites a value you've set
+manually.
+
 # System Requirements
 
 - .NET 10


### PR DESCRIPTION
## Summary

The ConBee II Zigbee dongle's serial device path was hardcoded to `/dev/ttyACM0` in both `docker-compose.yml` and the packaged `.deb` template, but ttyACM/ttyUSB enumeration order is not stable across reboots/replugs -- the deployed machine's dongle is currently at `/dev/ttyACM1`, breaking `haus_zigbee`'s device mapping and its `Zigbee__SerialPort` config.

- `docker-compose.yml` and `packaging/deb/etc/haus/docker-compose.yml.template` now read the device path from a new `ZIGBEE_SERIAL_PORT` env var via docker-compose's native `${VAR:-default}` interpolation (default `/dev/ttyACM0`, preserving current behavior when unset). docker-compose auto-loads this from a `.env` file next to the compose file.
- `packaging/deb/DEBIAN/postinst` now auto-detects the dongle at install/upgrade time and writes `ZIGBEE_SERIAL_PORT` into `/etc/haus/.env` (creating it if absent), so a packaged install self-heals without operator action. It prefers the dongle's stable `/dev/serial/by-id/...` symlink (matched by ConBee/dresden-elektronik vendor string), falling back to a bare `/dev/ttyACM*`/`ttyUSB*` scan if no by-id symlink exists. Detection is best-effort and never fails postinst if no dongle is attached, and it never overwrites an already-present `ZIGBEE_SERIAL_PORT` in `/etc/haus/.env` -- so an operator's manual override always wins.
- `readme.md` documents the new env var next to the existing Zigbee section.
- No C# changes: `Zigbee__SerialPort` already binds via `ConfigurationBuilder`'s standard `__` → `:` env-var convention into `ZigbeeConnectionOptions.SerialPort` (`src/Haus.Zigbee.Host/ServiceCollectionExtensions.cs`), confirmed by reading the binding code.

## Test plan

- [x] `sh -n` / `dash -n` syntax-checked `postinst` (matches its `#!/bin/sh` shebang; confirmed `/bin/sh` on this machine actually is `dash`)
- [x] Extracted the postinst detection/set functions into a scratch harness and ran them under real `dash` against faked `/dev` trees:
  - no devices present -> no `.env` written, function returns success (best-effort)
  - ConBee by-id symlink + a plain ttyACM0 both present -> by-id symlink is preferred
  - only a bare ttyACM1 present, no by-id -> falls back to it
  - existing `ZIGBEE_SERIAL_PORT` already in `.env` -> left untouched, not overwritten
- [x] `docker compose config` against scratch copies of both compose files (root and packaged template) with no `.env` (confirms default `/dev/ttyACM0` on both `devices:` and `Zigbee__SerialPort`) and with a `.env` setting `ZIGBEE_SERIAL_PORT` (confirms both the device mapping and env var pick up the override)
- [x] `dotnet build` on the affected/touched projects (`Haus.Utilities`, `Haus.Zigbee`, `Haus.Zigbee.Host`) -- all succeed with 0 warnings/errors. (Full-solution `dotnet build` fails only on `Haus.Acceptance.Tests`'s Playwright browser install, a pre-existing sandbox limitation needing an interactive `sudo` prompt -- unrelated to this change, which touches no C# code.)
- [x] `dotnet test tests/Haus.Utilities.Tests` -- 92/92 passing, no regressions
- Did **not** touch the live `/etc/haus` install, running containers, or the `haus-app` systemd service on the production machine, per instructions -- verified entirely via scratch copies in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)