### PR TITLE
feat(release): auto-detect version bump kind from commit messages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,8 @@ on:
   workflow_dispatch:
     inputs:
       version_bump:
-        description: 'What kind of release is this?'
-        required: true
-        default: 'patch'
+        description: 'What kind of release is this? Leave blank to auto-detect from commit messages.'
+        required: false
 permissions:
   contents: write
 jobs:
@@ -45,10 +44,16 @@ jobs:
       - name: Compute Next Version
         id: compute_version
         run: |
+          # Only export VERSION_BUMP when the human explicitly picked one via
+          # workflow_dispatch -- an empty input must reach compute-next-version.sh
+          # as "unset" so it falls through to commit-log auto-detection, not 'patch'.
+          if [ -n "$VERSION_BUMP_INPUT" ]; then
+            export VERSION_BUMP="$VERSION_BUMP_INPUT"
+          fi
           ./scripts/compute-next-version.sh
           echo "new_tag=$(cat next-version.txt)" >> "$GITHUB_OUTPUT"
         env:
-          VERSION_BUMP: ${{ github.event.inputs.version_bump || 'patch' }}
+          VERSION_BUMP_INPUT: ${{ github.event.inputs.version_bump }}
 
       - name: Publish App
         run: make publish

--- a/scripts/compute-next-version.sh
+++ b/scripts/compute-next-version.sh
@@ -6,6 +6,9 @@ set -ex
 # of truth for "what was the last release" is the tag history itself.
 CURRENT_VERSION=$(git tag --list 'v*' --sort=-v:refname | head -n1)
 export CURRENT_VERSION
-export VERSION_BUMP="${VERSION_BUMP:-patch}"
+
+# VERSION_BUMP is intentionally left unset when the caller didn't provide one --
+# the .NET command treats an empty VERSION_BUMP as "compute it from the commit
+# log since CURRENT_VERSION" rather than defaulting to patch here.
 
 dotnet run --project src/Haus.Utilities -- release bump-version

--- a/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
+++ b/src/Haus.Utilities/Git/ConventionalCommitMessageValidator.cs
@@ -15,9 +15,13 @@ public interface IConventionalCommitMessageValidator
     CommitMessageValidationResult Validate(string commitMessage);
 }
 
-public class ConventionalCommitMessageValidator : IConventionalCommitMessageValidator
+public readonly record struct ConventionalCommitHeader(string Type, bool IsBreakingChange);
+
+// Shared with CommitBumpKindClassifier so both the commit-msg hook and the release
+// bump-kind detection agree on what a conventional commit header looks like.
+public static class ConventionalCommitHeaderParser
 {
-    private static readonly string[] AllowedTypes =
+    public static readonly string[] AllowedTypes =
     [
         "feat",
         "fix",
@@ -33,23 +37,24 @@ public class ConventionalCommitMessageValidator : IConventionalCommitMessageVali
     ];
 
     private static readonly Regex HeaderPattern = new(
-        $"^({string.Join('|', AllowedTypes)})(\\([a-z0-9/_-]+\\))?!?: \\S.*$",
+        $"^(?<type>{string.Join('|', AllowedTypes)})(\\([a-z0-9/_-]+\\))?(?<breaking>!)?: \\S.*$",
         RegexOptions.Compiled
     );
 
-    public CommitMessageValidationResult Validate(string commitMessage)
+    public static bool TryParse(string header, out ConventionalCommitHeader parsed)
     {
-        var header = FirstLine(commitMessage);
+        var match = HeaderPattern.Match(header);
+        if (!match.Success)
+        {
+            parsed = default;
+            return false;
+        }
 
-        if (IsGitGeneratedHeader(header))
-            return CommitMessageValidationResult.Valid();
-
-        return HeaderPattern.IsMatch(header)
-            ? CommitMessageValidationResult.Valid()
-            : CommitMessageValidationResult.Invalid(BuildError(header));
+        parsed = new ConventionalCommitHeader(match.Groups["type"].Value, match.Groups["breaking"].Success);
+        return true;
     }
 
-    private static string FirstLine(string commitMessage)
+    public static string FirstLine(string commitMessage)
     {
         foreach (var line in commitMessage.Split('\n'))
         {
@@ -59,6 +64,21 @@ public class ConventionalCommitMessageValidator : IConventionalCommitMessageVali
         }
 
         return string.Empty;
+    }
+}
+
+public class ConventionalCommitMessageValidator : IConventionalCommitMessageValidator
+{
+    public CommitMessageValidationResult Validate(string commitMessage)
+    {
+        var header = ConventionalCommitHeaderParser.FirstLine(commitMessage);
+
+        if (IsGitGeneratedHeader(header))
+            return CommitMessageValidationResult.Valid();
+
+        return ConventionalCommitHeaderParser.TryParse(header, out _)
+            ? CommitMessageValidationResult.Valid()
+            : CommitMessageValidationResult.Invalid(BuildError(header));
     }
 
     private static bool IsGitGeneratedHeader(string header) =>
@@ -72,7 +92,7 @@ public class ConventionalCommitMessageValidator : IConventionalCommitMessageVali
             Commit messages must follow Conventional Commits format:
               type(scope): description
 
-            Allowed types: {string.Join(", ", AllowedTypes)}
+            Allowed types: {string.Join(", ", ConventionalCommitHeaderParser.AllowedTypes)}
 
             Examples:
               feat: add device discovery

--- a/src/Haus.Utilities/Git/GitCommitLogReader.cs
+++ b/src/Haus.Utilities/Git/GitCommitLogReader.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Haus.Utilities.Git;
+
+public interface IGitCommitLogReader
+{
+    IReadOnlyList<string> GetCommitMessagesSince(string? tag);
+}
+
+public class GitCommitLogReader : IGitCommitLogReader
+{
+    // %x1e (record separator) can't appear in a commit message body, so it's safe
+    // to split on -- unlike a newline, which commit messages routinely contain.
+    private const char CommitSeparator = '\x1e';
+
+    public IReadOnlyList<string> GetCommitMessagesSince(string? tag)
+    {
+        var range = string.IsNullOrWhiteSpace(tag) ? "HEAD" : $"{tag}..HEAD";
+        var output = RunGitLog(range);
+
+        return output
+            .Split(CommitSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(message => message.Trim())
+            .Where(message => message.Length > 0)
+            .ToArray();
+    }
+
+    private static string RunGitLog(string range)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("log");
+        startInfo.ArgumentList.Add(range);
+        startInfo.ArgumentList.Add($"--pretty=format:%B{CommitSeparator}");
+
+        using var process =
+            Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start 'git log' process.");
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"'git log {range}' failed: {error}");
+
+        return output;
+    }
+}

--- a/src/Haus.Utilities/Release/Commands/BumpVersionCommandHandler.cs
+++ b/src/Haus.Utilities/Release/Commands/BumpVersionCommandHandler.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Haus.Cqrs.Commands;
 using Haus.Utilities.Common.Cli;
+using Haus.Utilities.Git;
 using Microsoft.Extensions.Logging;
 
 namespace Haus.Utilities.Release.Commands;
@@ -11,8 +12,12 @@ namespace Haus.Utilities.Release.Commands;
 [Command("release", "bump-version")]
 public record BumpVersionCommand : ICommand;
 
-public class BumpVersionCommandHandler(ISemVerBumper bumper, ILogger<BumpVersionCommandHandler> logger)
-    : ICommandHandler<BumpVersionCommand>
+public class BumpVersionCommandHandler(
+    ISemVerBumper bumper,
+    ICommitBumpKindClassifier bumpKindClassifier,
+    IGitCommitLogReader commitLogReader,
+    ILogger<BumpVersionCommandHandler> logger
+) : ICommandHandler<BumpVersionCommand>
 {
     // Logging goes to the console (see HausLogger.ConfigureConsoleOnly), so the
     // computed version is written to a file rather than stdout -- scripts that
@@ -24,7 +29,11 @@ public class BumpVersionCommandHandler(ISemVerBumper bumper, ILogger<BumpVersion
     public async Task Handle(BumpVersionCommand request, CancellationToken cancellationToken)
     {
         var currentVersion = Environment.GetEnvironmentVariable("CURRENT_VERSION") ?? string.Empty;
-        var versionBump = Environment.GetEnvironmentVariable("VERSION_BUMP") ?? "patch";
+        var versionBumpOverride = Environment.GetEnvironmentVariable("VERSION_BUMP");
+
+        var versionBump = string.IsNullOrWhiteSpace(versionBumpOverride)
+            ? bumpKindClassifier.Classify(commitLogReader.GetCommitMessagesSince(currentVersion))
+            : versionBumpOverride;
 
         var nextVersion = bumper.Bump(currentVersion, versionBump);
         logger.LogInformation(

--- a/src/Haus.Utilities/Release/Commands/BumpVersionCommandHandler.cs
+++ b/src/Haus.Utilities/Release/Commands/BumpVersionCommandHandler.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Haus.Cqrs.Commands;
 using Haus.Utilities.Common.Cli;
-using Haus.Utilities.Git;
 using Microsoft.Extensions.Logging;
 
 namespace Haus.Utilities.Release.Commands;
@@ -13,9 +12,7 @@ namespace Haus.Utilities.Release.Commands;
 public record BumpVersionCommand : ICommand;
 
 public class BumpVersionCommandHandler(
-    ISemVerBumper bumper,
-    ICommitBumpKindClassifier bumpKindClassifier,
-    IGitCommitLogReader commitLogReader,
+    INextVersionResolver nextVersionResolver,
     ILogger<BumpVersionCommandHandler> logger
 ) : ICommandHandler<BumpVersionCommand>
 {
@@ -31,17 +28,8 @@ public class BumpVersionCommandHandler(
         var currentVersion = Environment.GetEnvironmentVariable("CURRENT_VERSION") ?? string.Empty;
         var versionBumpOverride = Environment.GetEnvironmentVariable("VERSION_BUMP");
 
-        var versionBump = string.IsNullOrWhiteSpace(versionBumpOverride)
-            ? bumpKindClassifier.Classify(commitLogReader.GetCommitMessagesSince(currentVersion))
-            : versionBumpOverride;
-
-        var nextVersion = bumper.Bump(currentVersion, versionBump);
-        logger.LogInformation(
-            "Bumping {CurrentVersion} ({BumpKind}) -> {NextVersion}",
-            currentVersion,
-            versionBump,
-            nextVersion
-        );
+        var nextVersion = nextVersionResolver.Resolve(currentVersion, versionBumpOverride);
+        logger.LogInformation("Bumping {CurrentVersion} -> {NextVersion}", currentVersion, nextVersion);
 
         await File.WriteAllTextAsync(OutputPath, nextVersion, cancellationToken);
     }

--- a/src/Haus.Utilities/Release/CommitBumpKindClassifier.cs
+++ b/src/Haus.Utilities/Release/CommitBumpKindClassifier.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Haus.Utilities.Git;
+
+namespace Haus.Utilities.Release;
+
+public interface ICommitBumpKindClassifier
+{
+    string Classify(IEnumerable<string> commitMessages);
+}
+
+public class CommitBumpKindClassifier : ICommitBumpKindClassifier
+{
+    private const string MajorBumpKind = "major";
+    private const string MinorBumpKind = "minor";
+    private const string PatchBumpKind = "patch";
+    private const string FeatCommitType = "feat";
+    private const string BreakingChangeFooterMarker = "BREAKING CHANGE:";
+
+    public string Classify(IEnumerable<string> commitMessages)
+    {
+        var hasBreakingChange = false;
+        var hasFeature = false;
+
+        foreach (var message in commitMessages)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+                continue;
+
+            if (HasBreakingChangeFooter(message))
+            {
+                hasBreakingChange = true;
+                continue;
+            }
+
+            var header = ConventionalCommitHeaderParser.FirstLine(message);
+            if (!ConventionalCommitHeaderParser.TryParse(header, out var parsed))
+                continue;
+
+            if (parsed.IsBreakingChange)
+                hasBreakingChange = true;
+            else if (parsed.Type == FeatCommitType)
+                hasFeature = true;
+        }
+
+        if (hasBreakingChange)
+            return MajorBumpKind;
+
+        return hasFeature ? MinorBumpKind : PatchBumpKind;
+    }
+
+    private static bool HasBreakingChangeFooter(string commitMessage) =>
+        commitMessage
+            .Split('\n')
+            .Any(line => line.TrimStart().StartsWith(BreakingChangeFooterMarker, StringComparison.Ordinal));
+}

--- a/src/Haus.Utilities/Release/NextVersionResolver.cs
+++ b/src/Haus.Utilities/Release/NextVersionResolver.cs
@@ -1,0 +1,24 @@
+using Haus.Utilities.Git;
+
+namespace Haus.Utilities.Release;
+
+public interface INextVersionResolver
+{
+    string Resolve(string currentVersion, string? versionBumpOverride);
+}
+
+public class NextVersionResolver(
+    ISemVerBumper bumper,
+    ICommitBumpKindClassifier bumpKindClassifier,
+    IGitCommitLogReader commitLogReader
+) : INextVersionResolver
+{
+    public string Resolve(string currentVersion, string? versionBumpOverride)
+    {
+        var versionBump = string.IsNullOrWhiteSpace(versionBumpOverride)
+            ? bumpKindClassifier.Classify(commitLogReader.GetCommitMessagesSince(currentVersion))
+            : versionBumpOverride;
+
+        return bumper.Bump(currentVersion, versionBump);
+    }
+}

--- a/src/Haus.Utilities/ServiceCollectionExtensions.cs
+++ b/src/Haus.Utilities/ServiceCollectionExtensions.cs
@@ -21,6 +21,8 @@ public static class ServiceCollectionExtensions
             .AddTransient<IDeviceTypeOptionsMerger, DeviceTypeOptionsMerger>()
             .AddTransient<IDebComposeVersionPinner, DebComposeVersionPinner>()
             .AddTransient<ISemVerBumper, SemVerBumper>()
+            .AddTransient<ICommitBumpKindClassifier, CommitBumpKindClassifier>()
+            .AddTransient<IGitCommitLogReader, GitCommitLogReader>()
             .AddTransient<IConventionalCommitMessageValidator, ConventionalCommitMessageValidator>()
             .AddSingleton<ICommandFactory, CommandFactory>();
     }

--- a/src/Haus.Utilities/ServiceCollectionExtensions.cs
+++ b/src/Haus.Utilities/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<ISemVerBumper, SemVerBumper>()
             .AddTransient<ICommitBumpKindClassifier, CommitBumpKindClassifier>()
             .AddTransient<IGitCommitLogReader, GitCommitLogReader>()
+            .AddTransient<INextVersionResolver, NextVersionResolver>()
             .AddTransient<IConventionalCommitMessageValidator, ConventionalCommitMessageValidator>()
             .AddSingleton<ICommandFactory, CommandFactory>();
     }

--- a/tests/Haus.Utilities.Tests/Release/CommitBumpKindClassifierTests.cs
+++ b/tests/Haus.Utilities.Tests/Release/CommitBumpKindClassifierTests.cs
@@ -1,0 +1,86 @@
+using Haus.Utilities.Release;
+using Xunit;
+
+namespace Haus.Utilities.Tests.Release;
+
+public class CommitBumpKindClassifierTests
+{
+    private readonly CommitBumpKindClassifier _classifier = new();
+
+    [Fact]
+    public void WhenThereAreNoCommitsThenBumpsPatch()
+    {
+        var bumpKind = _classifier.Classify([]);
+
+        Assert.Equal("patch", bumpKind);
+    }
+
+    [Theory]
+    [InlineData("fix: correct zigbee timeout")]
+    [InlineData("chore: update gitignore")]
+    [InlineData("docs: document release process")]
+    public void WhenAllCommitsArePatchLikeThenBumpsPatch(string commitMessage)
+    {
+        var bumpKind = _classifier.Classify([commitMessage]);
+
+        Assert.Equal("patch", bumpKind);
+    }
+
+    [Fact]
+    public void WhenAFeatCommitIsPresentThenBumpsMinor()
+    {
+        var bumpKind = _classifier.Classify(["fix: correct zigbee timeout", "feat: add device discovery"]);
+
+        Assert.Equal("minor", bumpKind);
+    }
+
+    [Fact]
+    public void WhenACommitHasBreakingChangeMarkerSuffixThenBumpsMajor()
+    {
+        var bumpKind = _classifier.Classify(["feat(api)!: change device response shape"]);
+
+        Assert.Equal("major", bumpKind);
+    }
+
+    [Fact]
+    public void WhenACommitHasBreakingChangeFooterThenBumpsMajor()
+    {
+        var bumpKind = _classifier.Classify([
+            "fix: correct zigbee timeout\n\nBREAKING CHANGE: removes the legacy endpoint",
+        ]);
+
+        Assert.Equal("major", bumpKind);
+    }
+
+    [Fact]
+    public void WhenBreakingAndFeatCommitsAreBothPresentThenMajorTakesPrecedence()
+    {
+        var bumpKind = _classifier.Classify(["feat: add device discovery", "fix(api)!: change response shape"]);
+
+        Assert.Equal("major", bumpKind);
+    }
+
+    [Theory]
+    [InlineData("Merge branch 'main' into feature/x")]
+    [InlineData("added device discovery")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhenCommitMessageIsNotConventionalThenItIsIgnored(string commitMessage)
+    {
+        var bumpKind = _classifier.Classify([commitMessage]);
+
+        Assert.Equal("patch", bumpKind);
+    }
+
+    [Fact]
+    public void WhenNonConventionalCommitsAreMixedWithAFeatCommitThenBumpsMinor()
+    {
+        var bumpKind = _classifier.Classify([
+            "Merge branch 'main' into feature/x",
+            "feat: add device discovery",
+            "added stray notes",
+        ]);
+
+        Assert.Equal("minor", bumpKind);
+    }
+}

--- a/tests/Haus.Utilities.Tests/Release/NextVersionResolverTests.cs
+++ b/tests/Haus.Utilities.Tests/Release/NextVersionResolverTests.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using Haus.Utilities.Git;
+using Haus.Utilities.Release;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace Haus.Utilities.Tests.Release;
+
+public class NextVersionResolverTests
+{
+    [Fact]
+    public void WhenVersionBumpOverrideIsSuppliedThenItTakesPrecedenceOverClassification()
+    {
+        var resolver = BuildResolver(["feat: add device discovery"]);
+
+        var nextVersion = resolver.Resolve("v1.0.2", "major");
+
+        Assert.Equal("v2.0.0", nextVersion);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhenVersionBumpOverrideIsMissingThenBumpKindIsClassifiedFromCommitLog(string? versionBumpOverride)
+    {
+        var resolver = BuildResolver(["fix: correct zigbee timeout", "feat: add device discovery"]);
+
+        var nextVersion = resolver.Resolve("v1.0.2", versionBumpOverride);
+
+        Assert.Equal("v1.1.0", nextVersion);
+    }
+
+    [Fact]
+    public void WhenNoOverrideAndNoQualifyingCommitsThenDelegatesPatchBumpToSemVerBumper()
+    {
+        var resolver = BuildResolver(["fix: correct zigbee timeout"]);
+
+        var nextVersion = resolver.Resolve("v1.0.2", null);
+
+        Assert.Equal("v1.0.3", nextVersion);
+    }
+
+    private static INextVersionResolver BuildResolver(IReadOnlyList<string> commitMessages)
+    {
+        var services = new ServiceCollection().AddHausUtilities();
+        services.RemoveAll<IGitCommitLogReader>();
+        services.AddSingleton<IGitCommitLogReader>(new StubGitCommitLogReader(commitMessages));
+
+        return services.BuildServiceProvider().GetRequiredService<INextVersionResolver>();
+    }
+
+    private class StubGitCommitLogReader(IReadOnlyList<string> commitMessages) : IGitCommitLogReader
+    {
+        public IReadOnlyList<string> GetCommitMessagesSince(string? tag) => commitMessages;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `CommitBumpKindClassifier` (`src/Haus.Utilities/Release/CommitBumpKindClassifier.cs`), which inspects the Conventional Commit messages since the latest `v*` tag and picks the release bump kind automatically:
  - any commit marked as a breaking change (`type(scope)!:` or a `BREAKING CHANGE:` footer/body line) → **major**
  - else any `feat` commit → **minor**
  - else → **patch**
  - non-conventional messages (merge commits, reverts, typos, etc.) are safely skipped rather than causing a crash
- Reuses the existing conventional-commit header parsing from `ConventionalCommitMessageValidator` (extracted into a shared `ConventionalCommitHeaderParser`) instead of duplicating a second regex.
- Adds `GitCommitLogReader` (`src/Haus.Utilities/Git/GitCommitLogReader.cs`), a small process-invocation wrapper around `git log <tag>..HEAD --pretty=format:%B` (with a record-separator-delimited format so multi-line commit bodies split correctly), following this codebase's existing shell-out style.
- `BumpVersionCommandHandler` now treats `VERSION_BUMP` as an **optional manual override**: if it's set (non-empty) it behaves exactly as before; if it's unset/empty, the handler classifies the bump kind itself from the commit log since `CURRENT_VERSION`. `SemVerBumper`'s actual major/minor/patch arithmetic is untouched.
- `.github/workflows/release.yaml`: the `version_bump` `workflow_dispatch` input is now optional (no forced default), and `VERSION_BUMP` is only exported to the "Compute Next Version" step when the human actually supplied a value — an empty input no longer gets coerced into a literal `patch`.
- `scripts/compute-next-version.sh` no longer defaults `VERSION_BUMP` to `patch` when unset; that default/detection now lives in the .NET command.

## How to force a manual bump kind

Nothing changes for anyone who wants an explicit bump: run the release workflow via `workflow_dispatch` and fill in `version_bump` with `patch`, `minor`, or `major` — that value is exported as `VERSION_BUMP` and still takes priority over auto-detection. Leave it blank to let the tool infer the bump kind from the commits being released.

## Test plan

- [x] `dotnet build` — `Haus.Utilities` and `Haus.Utilities.Tests` build clean
- [x] `dotnet test tests/Haus.Utilities.Tests --no-build` — 105/105 passing, including new `CommitBumpKindClassifierTests` and the unmodified `SemVerBumperTests`
- [x] `dotnet husky run --group pre-commit` (CSharpier/dotnet format) — clean
- [x] Manual CLI smoke test: `CURRENT_VERSION= VERSION_BUMP=` (no tag) → `v0.1.0`; `CURRENT_VERSION=v1.0.2 VERSION_BUMP=` (real repo history, patch-only commits) → `v1.0.3`; `CURRENT_VERSION=v1.0.2 VERSION_BUMP=major` (manual override) → `v2.0.0`
- [x] Commit message passes the repo's commit-msg Conventional Commits hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)