### PR TITLE
fix(deb): migrate pre-.deb manual install data into /var/lib/haus/data

### DIFF
--- a/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
+++ b/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
@@ -162,3 +162,38 @@ the `.deb`; `linux-install.sh` gets no further investment.
 
 Snap packaging is explicitly not pursued for this issue, for the confinement
 reasons above.
+
+## Follow-up (2026-08-15): legacy data migration
+
+The original acceptance criteria above cover a clean install and a `.deb`-to-`.deb`
+upgrade preserving `/var/lib/haus/data`, but not the transition *from*
+`scripts/linux-install.sh`'s manual install into the `.deb`. That install put
+the SQLite db, Zigbee state, and MQTT broker state under
+`/home/$(whoami)/haus/{haus_web,haus_zigbee,haus_mqtt}` (see
+`scripts/linux-install.sh`'s `HAUS_LOCATION`); a host upgrading straight to
+the `.deb` would silently start against the fresh, empty
+`/var/lib/haus/data` tree `postinst` creates, losing every device/room/log
+the operator had.
+
+`postinst` now migrates that legacy data forward the first time it runs on a
+host where it's found:
+
+- `find_legacy_data_dir` locates the legacy `~/haus` directory: it prefers
+  `$SUDO_USER`'s home (set by `sudo apt install`), then falls back to
+  scanning every `/home/*/haus` and `/root/haus` for one containing
+  `haus_web`, `haus_zigbee`, or `haus_mqtt`.
+- `migrate_legacy_data` copies (`cp -an`, never moves) each of those
+  subdirectories into the matching `/var/lib/haus/data/<subdir>`, then
+  writes a marker file at `/var/lib/haus/.legacy-data-migrated`.
+- Every later `postinst` run (package upgrades) checks that marker first and
+  skips the migration entirely once it exists, so a legacy directory that's
+  still sitting around can never overwrite newer `.deb`-produced data.
+- The legacy directory itself is never modified or deleted -- the migration
+  is purely additive, so a failed or unexpected copy can always be redone by
+  hand from the untouched original.
+
+Validated by sourcing `postinst`'s functions in a sandboxed fake filesystem
+(see the PR for `polly/fix-deb-data-migration`) covering: resolving the
+legacy dir via `$SUDO_USER`, a full first-time migration, a second run after
+the marker exists not clobbering newer data, and a fresh install with no
+legacy dir being a clean no-op.

--- a/packaging/deb/DEBIAN/postinst
+++ b/packaging/deb/DEBIAN/postinst
@@ -5,6 +5,7 @@ CONFIG_DIR="/etc/haus"
 DATA_DIR="/var/lib/haus/data"
 CERT_PASSWORD="password"
 ENV_FILE="$CONFIG_DIR/.env"
+LEGACY_MIGRATION_MARKER="/var/lib/haus/.legacy-data-migrated"
 
 # Prefers the ConBee II's stable /dev/serial/by-id symlink (survives reboots
 # and replugs) over a bare ttyACM/ttyUSB scan, since ttyACM/ttyUSB enumeration
@@ -46,12 +47,63 @@ set_detected_zigbee_serial_port() {
   echo "ZIGBEE_SERIAL_PORT=${detected_port}" >> "$ENV_FILE"
 }
 
+# The pre-.deb manual install (scripts/linux-install.sh) put everything
+# under "/home/$(whoami)/haus" for whichever user ran it -- haus_web,
+# haus_zigbee, and haus_mqtt hold the same SQLite db / zigbee state / mqtt
+# broker state that now live under $DATA_DIR. postinst runs as root, so
+# $SUDO_USER (set by `sudo apt install`) is checked first as the most
+# likely owner, then every /home/*/haus and /root/haus is scanned as a
+# fallback for installs done outside of sudo.
+find_legacy_data_dir() {
+  candidates=""
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    candidates="/home/$SUDO_USER/haus"
+  fi
+
+  for home_haus in /home/*/haus /root/haus; do
+    case " $candidates " in
+      *" $home_haus "*) continue ;;
+    esac
+    candidates="$candidates $home_haus"
+  done
+
+  for candidate in $candidates; do
+    if [ -d "$candidate/haus_web" ] || [ -d "$candidate/haus_zigbee" ] || [ -d "$candidate/haus_mqtt" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# One-time copy-forward from the legacy manual-install layout into $DATA_DIR
+# so upgrading to the .deb package doesn't silently start with an empty
+# database. Gated on $LEGACY_MIGRATION_MARKER so re-running postinst (e.g. a
+# later package upgrade) never re-copies stale legacy data over newer data
+# the .deb install has since produced. The legacy directory is only ever
+# read, never modified, in case the copy needs to be redone by hand.
+migrate_legacy_data() {
+  [ -f "$LEGACY_MIGRATION_MARKER" ] && return 0
+
+  legacy_dir=$(find_legacy_data_dir) || return 0
+
+  for subdir in haus_web haus_zigbee haus_mqtt; do
+    [ -d "$legacy_dir/$subdir" ] || continue
+    cp -an "$legacy_dir/$subdir/." "$DATA_DIR/$subdir/"
+  done
+
+  touch "$LEGACY_MIGRATION_MARKER"
+}
+
 case "$1" in
   configure)
     mkdir -p "$DATA_DIR/haus_web/logs" \
              "$DATA_DIR/haus_zigbee/logs" \
              "$DATA_DIR/haus_mqtt/data" \
              "$DATA_DIR/haus_mqtt/log"
+
+    migrate_legacy_data
 
     set_detected_zigbee_serial_port || true
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,13 @@ sudo apt purge haus-app          # also remove generated config/certs (data is s
 `scripts/linux-install.sh` (the previous manual install method) still works but is superseded by this package --
 it gets no further changes.
 
+If a host previously ran `scripts/linux-install.sh`, `postinst` migrates that install's data (SQLite db, Zigbee
+state, MQTT broker state) from its `~/haus` layout into `/var/lib/haus/data` automatically on first `.deb` install
+-- the original `~/haus` directory is only ever read, never modified or deleted, so it's safe to check afterward
+and remove by hand once you've confirmed the migrated data looks right. This only happens once: a marker file at
+`/var/lib/haus/.legacy-data-migrated` prevents re-running the migration (and clobbering newer data) on later
+package upgrades.
+
 # Commands
 
 ```bash


### PR DESCRIPTION
## Summary

`postinst` unconditionally `mkdir -p`'d a fresh, empty `/var/lib/haus/data` tree on every install. A host that had previously been set up with the pre-`.deb` manual install (`scripts/linux-install.sh`, which kept the SQLite db, Zigbee state, and MQTT broker state under `~/haus/{haus_web,haus_zigbee,haus_mqtt}`) would upgrade to the `.deb` package and silently start against that empty tree — losing every device/room/log the operator had, with no error or warning.

## Migration logic

- `find_legacy_data_dir` (in `packaging/deb/DEBIAN/postinst`) locates the legacy `~/haus` directory: it prefers `$SUDO_USER`'s home (set by `sudo apt install`), falling back to scanning every `/home/*/haus` and `/root/haus` for one containing `haus_web`, `haus_zigbee`, or `haus_mqtt`.
- `migrate_legacy_data` copies (`cp -an` — copy only, never move) each of those subdirectories into the matching `/var/lib/haus/data/<subdir>`, run right after `postinst` creates the fresh `/var/lib/haus/data` tree and before the service (re)starts.
- **Sentinel marker:** `/var/lib/haus/.legacy-data-migrated` is written the first time the copy runs. Every later `postinst` invocation (i.e. package upgrades) checks that marker first and skips the migration entirely once it exists, so a legacy directory that's still sitting around can never re-copy and clobber newer `.deb`-produced data.
- The legacy directory is only ever read — never modified or deleted — so the original is always there to inspect or redo the migration from by hand if something looks wrong.

## Validation

No existing automated harness runs `postinst` in isolation (`scripts/verify-deb-package-locally.sh` / `scripts/build-deb-package.sh` exercise the whole `.deb` install inside a nested systemd+Docker container, which needs a built `.deb` and real Docker-in-Docker). I validated the new shell functions directly by sourcing them into a sandboxed fake filesystem and exercising four scenarios:

1. `find_legacy_data_dir` resolves the legacy dir via `$SUDO_USER`.
2. A full first-time migration copies `haus_web`, `haus_zigbee`, and `haus_mqtt` contents into `/var/lib/haus/data`, writes the marker, and leaves the legacy source files untouched.
3. Re-running `migrate_legacy_data` after the marker exists does **not** re-copy — newer data already in `/var/lib/haus/data` is left alone.
4. A fresh install with no legacy directory anywhere is a clean no-op (no marker written, no files created).

All four scenarios passed. Also confirmed `packaging/deb/DEBIAN/postinst` parses cleanly under both `dash -n` and `sh -n`.

## Test plan

- [x] Sandboxed shell-function validation of `find_legacy_data_dir` / `migrate_legacy_data` (4 scenarios, see above)
- [x] `dash -n` / `sh -n` syntax check of `postinst`
- [x] Husky pre-commit / commit-msg hooks passed
- [ ] Full `.deb` install smoke test via `scripts/verify-deb-package-locally.sh` (not run here — requires a built `.deb` and nested Docker; recommend running this manually or via `make deb-package` before the next release if extra confidence is wanted)

Docs updated: `readme.md` (Installation (Ubuntu) section) and `docs/craft/plans/2026-08-14-ubuntu-package-intake.md` (follow-up addendum describing the migration behavior).

Co-authored-by: omnigent <noreply@omnigent.ai>