### PR TITLE
feat: gate device simulator behind configurable setting

### DIFF
--- a/src/Haus.Api.Client/Application/ApplicationApiClient.cs
+++ b/src/Haus.Api.Client/Application/ApplicationApiClient.cs
@@ -10,6 +10,7 @@ namespace Haus.Api.Client.Application;
 
 public interface IApplicationApiClient
 {
+    Task<ApplicationSettingsModel?> GetSettingsAsync();
     Task<ApplicationVersionModel?> GetLatestVersionAsync();
     Task<ListResult<ApplicationPackageModel>> GetLatestPackagesAsync();
     Task<HttpResponseMessage> DownloadLatestPackageAsync(int packageId);
@@ -20,6 +21,12 @@ public class ApplicationApiClient(HttpClient httpClient, IOptions<HausApiClientS
         IApplicationApiClient
 {
     private const string LatestVersionRoute = "application/latest-version";
+    private const string SettingsRoute = "application/settings";
+
+    public Task<ApplicationSettingsModel?> GetSettingsAsync()
+    {
+        return GetAsJsonAsync<ApplicationSettingsModel>(SettingsRoute);
+    }
 
     public Task<ApplicationVersionModel?> GetLatestVersionAsync()
     {

--- a/src/Haus.Api.Client/HausApiClient.cs
+++ b/src/Haus.Api.Client/HausApiClient.cs
@@ -189,6 +189,11 @@ public class HausApiClient(
         return ClientSettingsApiClient.GetClientSettingsAsync();
     }
 
+    public Task<ApplicationSettingsModel?> GetSettingsAsync()
+    {
+        return ApplicationApiClient.GetSettingsAsync();
+    }
+
     public Task<ApplicationVersionModel?> GetLatestVersionAsync()
     {
         return ApplicationApiClient.GetLatestVersionAsync();

--- a/src/Haus.Core.Models/Application/ApplicationSettingsModel.cs
+++ b/src/Haus.Core.Models/Application/ApplicationSettingsModel.cs
@@ -1,0 +1,3 @@
+namespace Haus.Core.Models.Application;
+
+public record ApplicationSettingsModel(bool IsDeviceSimulatorEnabled);

--- a/src/Haus.Hosting/HausLogger.cs
+++ b/src/Haus.Hosting/HausLogger.cs
@@ -37,6 +37,7 @@ public class HausLogger : ILogsDirectoryProvider
 
     public static void ConfigureDefaultLogging(string appName)
     {
+        var previousLogger = Log.Logger;
         AppName = appName;
         Log.Logger = CreateDefaultLoggerConfiguration(appName)
             .WriteTo.File(
@@ -46,6 +47,9 @@ public class HausLogger : ILogsDirectoryProvider
                 retainedFileCountLimit: 20
             )
             .CreateLogger();
+
+        if (previousLogger is IDisposable disposableLogger)
+            disposableLogger.Dispose();
     }
 
     public static void ConfigureConsoleOnly(string appName)

--- a/src/Haus.Site.Host/Shell/ShellDrawerView.razor
+++ b/src/Haus.Site.Host/Shell/ShellDrawerView.razor
@@ -1,10 +1,16 @@
+@using Haus.Api.Client
+@inject IHausApiClient ApiClient
+
 <MudDrawer Open="IsOpen">
     <MudNavMenu>
         <MudNavLink Href="/welcome">Welcome</MudNavLink>
         <AuthorizeView>
             <Authorized>
                 <MudNavLink Href="/devices">Devices</MudNavLink>
-                <MudNavLink Href="/device-simulator">Device Simulator</MudNavLink>
+                @if (_isDeviceSimulatorEnabled)
+                {
+                    <MudNavLink Href="/device-simulator">Device Simulator</MudNavLink>
+                }
                 <MudNavLink Href="/health">Health</MudNavLink>
                 <MudNavLink Href="/rooms">Rooms</MudNavLink>
             </Authorized>
@@ -14,4 +20,12 @@
 
 @code {
     [Parameter] public bool IsOpen { get; set; }
+
+    private bool _isDeviceSimulatorEnabled;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var settings = await ApiClient.GetSettingsAsync();
+        _isDeviceSimulatorEnabled = settings?.IsDeviceSimulatorEnabled ?? false;
+    }
 }

--- a/src/Haus.Web.Host/Application/ApplicationController.cs
+++ b/src/Haus.Web.Host/Application/ApplicationController.cs
@@ -3,15 +3,25 @@ using System.Net.Mime;
 using System.Threading.Tasks;
 using Haus.Core;
 using Haus.Core.Application.Queries;
+using Haus.Core.Models.Application;
 using Haus.Cqrs;
 using Haus.Web.Host.Common.Mvc;
+using Haus.Web.Host.DeviceSimulator;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Haus.Web.Host.Application;
 
 [Route("api/application")]
-public class ApplicationController(IHausBus hausBus) : HausBusController(hausBus)
+public class ApplicationController(IHausBus hausBus, IOptions<DeviceSimulatorOptions> deviceSimulatorOptions)
+    : HausBusController(hausBus)
 {
+    [HttpGet("settings")]
+    public IActionResult GetSettings()
+    {
+        return Ok(new ApplicationSettingsModel(deviceSimulatorOptions.Value.Enabled));
+    }
+
     [HttpGet("latest-version")]
     public Task<IActionResult> GetLatestVersion()
     {

--- a/src/Haus.Web.Host/Common/Mvc/ExcludeControllerFeatureProvider.cs
+++ b/src/Haus.Web.Host/Common/Mvc/ExcludeControllerFeatureProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+
+namespace Haus.Web.Host.Common.Mvc;
+
+public class ExcludeControllerFeatureProvider(Type excludedControllerType) : ControllerFeatureProvider
+{
+    private readonly TypeInfo _excludedTypeInfo = excludedControllerType.GetTypeInfo();
+
+    protected override bool IsController(TypeInfo typeInfo)
+    {
+        return typeInfo != _excludedTypeInfo && base.IsController(typeInfo);
+    }
+
+    public static void ReplaceDefaultProvider(ApplicationPartManager manager, Type excludedControllerType)
+    {
+        var defaultProvider = manager.FeatureProviders.OfType<ControllerFeatureProvider>().ToList();
+        foreach (var provider in defaultProvider)
+            manager.FeatureProviders.Remove(provider);
+
+        manager.FeatureProviders.Add(new ExcludeControllerFeatureProvider(excludedControllerType));
+    }
+}

--- a/src/Haus.Web.Host/DeviceSimulator/DeviceSimulatorFeature.cs
+++ b/src/Haus.Web.Host/DeviceSimulator/DeviceSimulatorFeature.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Haus.Web.Host.DeviceSimulator;
+
+public static class DeviceSimulatorFeature
+{
+    public const string EnabledConfigurationKey = "DeviceSimulator:Enabled";
+
+    public static bool IsEnabled(IConfiguration configuration, IHostEnvironment environment)
+    {
+        var explicitValue = configuration.GetValue<bool?>(EnabledConfigurationKey);
+        return explicitValue ?? IsEnabledByDefault(environment);
+    }
+
+    private static bool IsEnabledByDefault(IHostEnvironment environment)
+    {
+        return environment.IsDevelopment() || environment.IsAcceptance();
+    }
+}

--- a/src/Haus.Web.Host/DeviceSimulator/DeviceSimulatorOptions.cs
+++ b/src/Haus.Web.Host/DeviceSimulator/DeviceSimulatorOptions.cs
@@ -1,0 +1,6 @@
+namespace Haus.Web.Host.DeviceSimulator;
+
+public class DeviceSimulatorOptions
+{
+    public bool Enabled { get; set; }
+}

--- a/src/Haus.Web.Host/ServiceCollectionExtensions.cs
+++ b/src/Haus.Web.Host/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Haus.Web.Host.Application;
 using Haus.Web.Host.Auth;
 using Haus.Web.Host.Common.GitHub;
 using Haus.Web.Host.Common.Mqtt;
+using Haus.Web.Host.Common.Mvc;
 using Haus.Web.Host.Common.SignalR;
 using Haus.Web.Host.DeviceSimulator;
 using Haus.Web.Host.Diagnostics;
@@ -21,14 +22,21 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 
 namespace Haus.Web.Host;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddHausWebHost(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddHausWebHost(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment
+    )
     {
-        return services
+        var isDeviceSimulatorEnabled = DeviceSimulatorFeature.IsEnabled(configuration, environment);
+
+        services
             .AddHausCore(opts =>
             {
                 opts.UseSqlite(
@@ -48,15 +56,20 @@ public static class ServiceCollectionExtensions
                 configuration.Bind("GitHub", opts);
                 opts.PersonalAccessToken = configuration["GITHUB_TOKEN"] ?? "";
             })
+            .Configure<DeviceSimulatorOptions>(opts => opts.Enabled = isDeviceSimulatorEnabled)
             .AddHausMqtt()
             .AddHausCqrs(typeof(ServiceCollectionExtensions).Assembly)
             .AddTransient<ILatestReleaseProvider, GithubLatestReleaseProvider>()
             .AddHostedService<MqttMessageRouter>()
             .AddHostedService<DiagnosticsMqttListener>()
-            .AddHostedService<DeviceSimulatorStatePublisher>()
             .AddHostedService<HealthListener>()
             .AddHostedService<RoomVacancyBackgroundService>()
             .AddSingleton<IHealthCheckPublisher, HealthPublisher>();
+
+        if (isDeviceSimulatorEnabled)
+            services.AddHostedService<DeviceSimulatorStatePublisher>();
+
+        return services;
     }
 
     public static IServiceCollection AddHausAuthentication(
@@ -85,9 +98,17 @@ public static class ServiceCollectionExtensions
         });
     }
 
-    public static IServiceCollection AddHausRestApi(this IServiceCollection services)
+    public static IServiceCollection AddHausRestApi(this IServiceCollection services, bool isDeviceSimulatorEnabled)
     {
-        services.AddControllers().AddControllersAsServices();
+        var mvcBuilder = services.AddControllers().AddControllersAsServices();
+        if (!isDeviceSimulatorEnabled)
+        {
+            mvcBuilder.ConfigureApplicationPartManager(manager =>
+            {
+                ExcludeControllerFeatureProvider.ReplaceDefaultProvider(manager, typeof(DeviceSimulatorController));
+            });
+        }
+
         return services.AddCors(opts =>
         {
             opts.AddDefaultPolicy(policy =>

--- a/src/Haus.Web.Host/Startup.cs
+++ b/src/Haus.Web.Host/Startup.cs
@@ -17,19 +17,23 @@ namespace Haus.Web.Host;
 public class Startup
 {
     private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
 
-    public Startup(IConfiguration configuration)
+    public Startup(IConfiguration configuration, IHostEnvironment environment)
     {
         _configuration = configuration;
+        _environment = environment;
     }
 
     public void ConfigureServices(IServiceCollection services)
     {
+        var isDeviceSimulatorEnabled = DeviceSimulatorFeature.IsEnabled(_configuration, _environment);
+
         services
             .AddHausLogging()
-            .AddHausWebHost(_configuration)
+            .AddHausWebHost(_configuration, _environment)
             .AddHausAuthentication(_configuration)
-            .AddHausRestApi()
+            .AddHausRestApi(isDeviceSimulatorEnabled)
             .AddHausRealtimeApi()
             .AddHausHealthChecks();
     }
@@ -43,13 +47,16 @@ public class Startup
         if (!env.IsAcceptance())
             app.UseHttpsRedirection();
 
+        var isDeviceSimulatorEnabled = DeviceSimulatorFeature.IsEnabled(_configuration, env);
+
         app.UseRouting()
             .UseAuthentication()
             .UseAuthorization()
             .UseEndpoints(endpoints =>
             {
                 endpoints.MapHub<DiagnosticsHub>(HausRealtimeSources.Diagnostics);
-                endpoints.MapHub<DeviceSimulatorHub>(HausRealtimeSources.DeviceSimulator);
+                if (isDeviceSimulatorEnabled)
+                    endpoints.MapHub<DeviceSimulatorHub>(HausRealtimeSources.DeviceSimulator);
                 endpoints.MapHub<EventsHub>(HausRealtimeSources.Events);
                 endpoints.MapHub<HealthHub>(HausRealtimeSources.Health);
                 endpoints.MapControllers();

--- a/tests/Haus.Site.Host.Tests/Shell/ShellDrawerViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Shell/ShellDrawerViewTests.cs
@@ -1,17 +1,40 @@
 using System.Linq;
+using System.Threading.Tasks;
+using Haus.Core.Models.Application;
 using Haus.Site.Host.Shell;
 using Haus.Site.Host.Tests.Support;
+using Haus.Testing.Support;
 using MudBlazor;
 
 namespace Haus.Site.Host.Tests.Shell;
 
 public class ShellDrawerViewTests : HausSiteTestContext
 {
+    private const string SettingsUrl = "/api/application/settings";
+
     [Fact]
-    public void WhenRenderedThenShowsNavigationLinks()
+    public async Task WhenDeviceSimulatorIsEnabledThenShowsNavigationLinkForIt()
     {
+        await HausApiHandler.SetupGetAsJson(SettingsUrl, new ApplicationSettingsModel(IsDeviceSimulatorEnabled: true));
+
         var view = RenderView<ShellDrawerView>();
 
-        Assert.Equal(5, view.FindAllByComponent<MudNavLink>().Count());
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(5, view.FindAllByComponent<MudNavLink>().Count());
+        });
+    }
+
+    [Fact]
+    public async Task WhenDeviceSimulatorIsDisabledThenHidesNavigationLinkForIt()
+    {
+        await HausApiHandler.SetupGetAsJson(SettingsUrl, new ApplicationSettingsModel(IsDeviceSimulatorEnabled: false));
+
+        var view = RenderView<ShellDrawerView>();
+
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(4, view.FindAllByComponent<MudNavLink>().Count());
+        });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Shell/ShellLayoutViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Shell/ShellLayoutViewTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Haus.Core.Models.Application;
 using Haus.Site.Host.Shell;
 using Haus.Site.Host.Tests.Support;
 using Microsoft.AspNetCore.Components.Web;
@@ -8,6 +9,15 @@ namespace Haus.Site.Host.Tests.Shell;
 
 public class ShellLayoutViewTests : HausSiteTestContext
 {
+    public override async Task InitializeAsync()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            "/api/application/settings",
+            new ApplicationSettingsModel(IsDeviceSimulatorEnabled: true)
+        );
+        await base.InitializeAsync();
+    }
+
     [Fact]
     public async Task WhenMenuIsToggledThenMenuIsClosed()
     {

--- a/tests/Haus.Web.Host.Tests/Application/ApplicationSettingsApiTests.cs
+++ b/tests/Haus.Web.Host.Tests/Application/ApplicationSettingsApiTests.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Haus.Api.Client;
+using Haus.Web.Host.Tests.Support;
+using Xunit;
+
+namespace Haus.Web.Host.Tests.Application;
+
+[Collection(HausWebHostCollectionFixture.Name)]
+public class ApplicationSettingsApiTests(HausWebHostApplicationFactory factory)
+{
+    private readonly IHausApiClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task WhenGettingApplicationSettingsThenReturnsDeviceSimulatorEnabledState()
+    {
+        var settings = await _client.GetSettingsAsync();
+
+        Assert.NotNull(settings);
+        Assert.True(settings.IsDeviceSimulatorEnabled);
+    }
+}

--- a/tests/Haus.Web.Host.Tests/DeviceSimulator/DeviceSimulatorFeatureGatingTests.cs
+++ b/tests/Haus.Web.Host.Tests/DeviceSimulator/DeviceSimulatorFeatureGatingTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Haus.Web.Host.Tests.Support;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Haus.Web.Host.Tests.DeviceSimulator;
+
+[Collection(HausWebHostCollectionFixture.Name)]
+public class DeviceSimulatorFeatureGatingTests(HausWebHostApplicationFactory factory)
+{
+    [Fact]
+    public async Task WhenDeviceSimulatorIsDisabledThenControllerEndpointIsUnavailable()
+    {
+        using var disabledFactory = factory.WithWebHostBuilder(builder => builder.UseEnvironment("Production"));
+        var client = disabledFactory.CreateClient();
+
+        var response = await client.PostAsync("/api/device-simulator/reset", new ByteArrayContent([]));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WhenDeviceSimulatorIsDisabledThenRealtimeHubIsUnavailable()
+    {
+        using var disabledFactory = factory.WithWebHostBuilder(builder => builder.UseEnvironment("Production"));
+        disabledFactory.CreateClient();
+        var connection = new HubConnectionBuilder()
+            .WithUrl(
+                "http://localhost/hubs/device-simulator",
+                o => o.HttpMessageHandlerFactory = _ => disabledFactory.Server.CreateHandler()
+            )
+            .Build();
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => connection.StartAsync());
+    }
+}

--- a/tests/Haus.Web.Host.Tests/DeviceSimulator/DeviceSimulatorFeatureTests.cs
+++ b/tests/Haus.Web.Host.Tests/DeviceSimulator/DeviceSimulatorFeatureTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Haus.Web.Host.DeviceSimulator;
+using Haus.Web.Host.Tests.Support;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Haus.Web.Host.Tests.DeviceSimulator;
+
+public class DeviceSimulatorFeatureTests
+{
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Acceptance")]
+    public void WhenNoExplicitValueConfiguredAndEnvironmentDefaultsToEnabledThenIsEnabled(string environmentName)
+    {
+        var isEnabled = DeviceSimulatorFeature.IsEnabled(BuildConfiguration(), BuildEnvironment(environmentName));
+
+        Assert.True(isEnabled);
+    }
+
+    [Fact]
+    public void WhenNoExplicitValueConfiguredAndEnvironmentIsProductionThenIsDisabled()
+    {
+        var isEnabled = DeviceSimulatorFeature.IsEnabled(BuildConfiguration(), BuildEnvironment("Production"));
+
+        Assert.False(isEnabled);
+    }
+
+    [Fact]
+    public void WhenExplicitlyEnabledInConfigurationThenOverridesProductionDefault()
+    {
+        var configuration = BuildConfiguration(
+            new Dictionary<string, string?> { ["DeviceSimulator:Enabled"] = "true" }
+        );
+
+        var isEnabled = DeviceSimulatorFeature.IsEnabled(configuration, BuildEnvironment("Production"));
+
+        Assert.True(isEnabled);
+    }
+
+    [Fact]
+    public void WhenExplicitlyDisabledInConfigurationThenOverridesDevelopmentDefault()
+    {
+        var configuration = BuildConfiguration(
+            new Dictionary<string, string?> { ["DeviceSimulator:Enabled"] = "false" }
+        );
+
+        var isEnabled = DeviceSimulatorFeature.IsEnabled(configuration, BuildEnvironment("Development"));
+
+        Assert.False(isEnabled);
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?>? values = null)
+    {
+        return new ConfigurationBuilder().AddInMemoryCollection(values ?? []).Build();
+    }
+
+    private static IHostEnvironment BuildEnvironment(string environmentName)
+    {
+        return new StubHostEnvironment(environmentName);
+    }
+}

--- a/tests/Haus.Web.Host.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Haus.Web.Host.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Haus.Web.Host.DeviceSimulator;
+using Haus.Web.Host.Tests.Support;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Haus.Web.Host.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public async Task WhenDeviceSimulatorIsEnabledThenStatePublisherHostedServiceIsRegistered()
+    {
+        await using var provider = BuildProvider("Development");
+
+        var hostedServices = provider.GetServices<IHostedService>();
+
+        Assert.Contains(hostedServices, service => service is DeviceSimulatorStatePublisher);
+    }
+
+    [Fact]
+    public async Task WhenDeviceSimulatorIsDisabledThenStatePublisherHostedServiceIsNotRegistered()
+    {
+        await using var provider = BuildProvider("Production");
+
+        var hostedServices = provider.GetServices<IHostedService>();
+
+        Assert.DoesNotContain(hostedServices, service => service is DeviceSimulatorStatePublisher);
+    }
+
+    private static ServiceProvider BuildProvider(string environmentName)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["Database:ConnectionString"] = "Data Source=:memory:" }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHausWebHost(configuration, new StubHostEnvironment(environmentName));
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Haus.Web.Host.Tests/Support/StubHostEnvironment.cs
+++ b/tests/Haus.Web.Host.Tests/Support/StubHostEnvironment.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+
+namespace Haus.Web.Host.Tests.Support;
+
+public sealed class StubHostEnvironment(string environmentName) : IWebHostEnvironment
+{
+    public string EnvironmentName { get; set; } = environmentName;
+    public string ApplicationName { get; set; } = "Haus.Web.Host.Tests";
+    public string ContentRootPath { get; set; } = ".";
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    public string WebRootPath { get; set; } = ".";
+    public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+}


### PR DESCRIPTION
## Summary

- Adds a `DeviceSimulator:Enabled` configuration setting. When not explicitly set, it defaults based on the hosting environment: `true` in Development/Acceptance, `false` in Production (or any unrecognized environment). An explicit value always wins over the environment-based default (`DeviceSimulatorFeature.IsEnabled`).
- The resolved value gates the device simulator end to end on the web host: the `DeviceSimulatorStatePublisher` hosted service is only registered when enabled, the `/hubs/device-simulator` SignalR hub is only mapped when enabled, and the `DeviceSimulatorController` is excluded from the MVC application part manager (via a new `ExcludeControllerFeatureProvider`) when disabled, so the REST endpoints 404.
- Adds `GET api/application/settings`, returning `ApplicationSettingsModel { IsDeviceSimulatorEnabled }`, and a matching `IApplicationApiClient.GetSettingsAsync()` client method.
- The Blazor site's `ShellDrawerView` fetches settings on init and only renders the "Device Simulator" nav link when the API reports it enabled, keeping the nav in sync with the backend gate.

## Test plan

- [x] `dotnet build` succeeds for all projects except `Haus.Acceptance.Tests`, which fails only because Playwright's browser install requires `sudo` with no terminal in this sandbox (pre-existing environment limitation, confirmed on `main` too — unrelated to this change)
- [x] `Haus.Web.Host.Tests` — 53/58 pass; the 5 failures are pre-existing and environmental (missing `GITHUB_TOKEN` for GitHub-backed endpoints, missing log files for `LogsApiTests`), confirmed present on `main` before this change
- [x] `Haus.Site.Host.Tests` — 107/107 pass
- [x] `Haus.Core.Tests` — 222/222 pass
- [x] New coverage: `DeviceSimulatorFeatureTests` (environment-default + explicit-override matrix), `ServiceCollectionExtensionsTests` (hosted service DI gating), `DeviceSimulatorFeatureGatingTests` (controller/hub unavailable when disabled), `ApplicationSettingsApiTests`, `ShellDrawerViewTests` (nav link shown/hidden)
- [x] CSharpier + `dotnet format` applied via the Husky pre-commit hook on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)