### PR TITLE
feat(acceptance): record Playwright video for every acceptance test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,3 +38,12 @@ jobs:
 
       - name: Run Acceptance Tests
         run: make test-acceptance
+
+      - name: Upload Playwright videos
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-videos
+          path: tests/Haus.Acceptance.Tests/bin/**/playwright/videos/*.webm
+          if-no-files-found: ignore
+          retention-days: 7

--- a/tests/Haus.Acceptance.Tests/Support/HausPageTest.cs
+++ b/tests/Haus.Acceptance.Tests/Support/HausPageTest.cs
@@ -18,6 +18,8 @@ public class HausPageTest : PageTest
             BaseURL = "https://localhost:15003",
             IgnoreHTTPSErrors = true,
             ScreenSize = new ScreenSize { Width = 1920, Height = 1080 },
+            RecordVideoDir = "playwright/videos",
+            RecordVideoSize = new RecordVideoSize { Width = 1920, Height = 1080 },
         };
     }
 


### PR DESCRIPTION
## Summary
- Reviewers currently only see pass/fail for `Haus.Acceptance.Tests`; there's no way to see what a UI flow actually looked like when checking a build.
- Enables Playwright's `RecordVideoDir`/`RecordVideoSize` on `HausPageTest.ContextOptions()` (the shared base class every acceptance flow fixture inherits). Because video recording is driven purely by context-creation options in Playwright's API, this requires **zero per-test-class code** — every fixture gets a video automatically, the same "no per-test-class code" goal that a shared `[SetUp]`/`[TearDown]` gives tracing (that centralization is a separate, still-open change — PR #36 — not part of this PR; `main` doesn't have tracing centralized yet).
- Videos land at `tests/Haus.Acceptance.Tests/bin/**/playwright/videos/*.webm`, mirroring the `playwright/traces` directory convention used for trace zips.
- CI (`.github/workflows/main.yaml`) uploads them as a `playwright-videos` build artifact via `actions/upload-artifact@v4` with `if: always()` (every run, success or failure), `if-no-files-found: ignore`, 7-day retention — same shape as the trace-zip upload in PR #36.
- Nothing deletes `tests/Haus.Acceptance.Tests/bin/**` between the test run and CI's artifact-upload step in `make test-acceptance`, so the video files are naturally preserved; no Makefile change was needed for that.
- No test assertions or behavior changed — infra only.

## Mechanism
Playwright's video recording isn't a manual start/stop call like tracing — setting `RecordVideoDir` on `BrowserNewContextOptions` is enough; the video is written to disk automatically when the context/page closes (which `Microsoft.Playwright.NUnit`'s `ContextTest` base class already does per test in its own `[TearDown]`).

## What's verified vs. not
Verified in this sandbox:
- `dotnet build` succeeds for `Haus.Core.Tests`, `Haus.Web.Host.Tests`, `Haus.Site.Host.Tests` (0 errors/warnings from the change).
- `Haus.Core.Tests`: 222/222 passing.
- `Haus.Site.Host.Tests`: 107/107 passing.
- `make test-unit` (`Haus.Web.Host.Tests`, real MQTT broker): 55/58 passing — the 3 failures are all in `ApplicationApiTests` and fail identically without this change, due to a missing `GITHUB_TOKEN` in this sandbox (same pre-existing gap noted in PR #36).
- CSharpier: clean (`dotnet csharpier check` on the changed file; the pre-commit hook also ran `format`/CSharpier and re-committed cleanly).
- Commit message passes the Conventional Commits `commit-msg` hook.

**Not verified** — this sandbox has neither Auth0 credentials (`AUTH_DOMAIN`/`AUTH_CLIENT_ID`/etc. all unset) nor a working Playwright browser install (`dotnet build tests/Haus.Acceptance.Tests` fails during its `InstallBrowsers` post-build target: `sudo: A terminal is required to authenticate` — confirmed pre-existing/unrelated to this change by reproducing the same failure with the change stashed). So `make test-acceptance` could not be run here, and no `.webm` file has actually been produced and inspected for non-zero size in this session. That needs confirming on real CI or a machine with Docker + Auth0 creds + a working Playwright browser install: run `make test-acceptance` and check that non-zero-size `.webm` files land under `tests/Haus.Acceptance.Tests/bin/**/playwright/videos/`, and that the `playwright-videos` artifact is attached to the resulting GitHub Actions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)