### PR TITLE
fix(packaging): replace non-portable cp -n with --update=none

### DIFF
--- a/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
+++ b/docs/craft/plans/2026-08-14-ubuntu-package-intake.md
@@ -182,7 +182,7 @@ host where it's found:
   `$SUDO_USER`'s home (set by `sudo apt install`), then falls back to
   scanning every `/home/*/haus` and `/root/haus` for one containing
   `haus_web`, `haus_zigbee`, or `haus_mqtt`.
-- `migrate_legacy_data` copies (`cp -an`, never moves) each of those
+- `migrate_legacy_data` copies (`cp -a --update=none`, never moves) each of those
   subdirectories into the matching `/var/lib/haus/data/<subdir>`, then
   writes a marker file at `/var/lib/haus/.legacy-data-migrated`.
 - Every later `postinst` run (package upgrades) checks that marker first and

--- a/packaging/deb/DEBIAN/postinst
+++ b/packaging/deb/DEBIAN/postinst
@@ -90,7 +90,7 @@ migrate_legacy_data() {
 
   for subdir in haus_web haus_zigbee haus_mqtt; do
     [ -d "$legacy_dir/$subdir" ] || continue
-    cp -an "$legacy_dir/$subdir/." "$DATA_DIR/$subdir/"
+    cp -a --update=none "$legacy_dir/$subdir/." "$DATA_DIR/$subdir/"
   done
 
   touch "$LEGACY_MIGRATION_MARKER"


### PR DESCRIPTION
## Summary
- `packaging/deb/DEBIAN/postinst`'s `migrate_legacy_data()` used `cp -an`, which triggers coreutils' portability warning (`-n`/`--no-clobber` combined with `-a` is non-portable and may change behavior in a future release). Replaced with `cp -a --update=none`, preserving the archive + never-overwrite-existing-data semantics.
- Updated `docs/craft/plans/2026-08-14-ubuntu-package-intake.md`, which quoted the old `cp -an` invocation verbatim, to match.
- Repo-wide grep found no other `cp -n`/`cp --no-clobber` usages to fix.

## Test plan
- [x] `sh -n packaging/deb/DEBIAN/postinst` — syntax OK
- [x] `shellcheck` (via `koalaman/shellcheck:stable` Docker image, no local install available) against the touched file and the other packaging scripts — no findings on the changed line; only pre-existing unrelated info-level notices
- [x] Manually exercised the exact `cp -a --update=none ...` invocation against a temp dir simulating legacy vs. new data: no warning on stderr, existing destination file preserved, new file copied — confirms no-clobber/archive semantics unchanged