### PR TITLE
chore(deps): update outdated dependencies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Playwright traces
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-traces
           path: tests/Haus.Acceptance.Tests/bin/**/playwright/traces/*.zip
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload Playwright videos
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-videos
           path: tests/Haus.Acceptance.Tests/bin/**/playwright/videos/*.webm


### PR DESCRIPTION
## Summary

Full dependency audit of the HAUS repo per the maintenance discipline (one logical update per commit, changelog-reviewed, full suites run after each). Scope covered: .NET NuGet packages, `.config/dotnet-tools.json` tools, `global.json` SDK pin, npm/JS packages, Docker base images, and GitHub Actions versions.

**Result: everything was already current except one GitHub Actions pin.**

### Updated

- **`actions/upload-artifact`: v4 → v7** (`.github/workflows/main.yaml`, both Playwright trace/video upload steps)
  - v5: Node runtime bump 20→24 (hosted GitHub runners already support this; no action needed on our side)
  - v6: makes Node 24 the default runtime (same, transparent on hosted runners)
  - v7: adds an opt-in `archive: false` direct-upload mode; not used here
  - No change to our usage — `name`/`path`/`if-no-files-found`/`retention-days` are unaffected in all versions since v4. Changelogs reviewed via the GitHub releases API for v5.0.0, v6.0.0, and v7.0.0.

### Checked, already up to date (no change needed)

- **NuGet packages** — `dotnet outdated` and `dotnet list package --outdated` both report zero outdated packages across all 24 projects in `Haus.slnx` (checked against nuget.org).
- **Local dotnet tools** (`.config/dotnet-tools.json`) — `dotnet-ef` 10.0.11, `dotnet-reportgenerator-globaltool` 5.5.11, `csharpier` 1.3.0, `husky` 0.9.1, `dotnet-outdated-tool` 4.8.1, `powershell` 7.6.5 are each already the latest stable release on NuGet.
- **`global.json` SDK pin** — left at `10.0.100`/`rollForward: latestMinor` intentionally. A newer 10.0.x SDK release exists, but `rollForward: latestMinor` already means each environment (this sandbox, CI) floats to the newest installed 10.x SDK without needing the floor raised — and raising the floor to a version not installed in every environment risks breaking builds where only an older 10.x SDK is present. No behavior change either way.
- **npm/yarn/pnpm** — no `package.json` exists anywhere in the repo; N/A.
- **Docker base images** (`haus-dockerfile`, `haus-site-dockerfile`, `docker-compose.yml`, `docker-compose.local.yml`, `scripts/deb-verify/Dockerfile`) — all pinned images (`mcr.microsoft.com/dotnet/aspnet:10.0`, `nginx:alpine`, `eclipse-mosquitto:latest`, `ubuntu:24.04`, and the repo's own `*-latest` tags) are already floating/major tags with nothing to bump.
- **Other GitHub Actions** — `actions/checkout@v7`, `actions/setup-dotnet@v6`, `taiki-e/install-action@v2`, `softprops/action-gh-release@v3` are already pinned to the latest major.

## Gates run

- `dotnet build` (whole solution) — **green**, with one caveat: the `Haus.Acceptance.Tests` project's post-build target runs `playwright install --with-deps`, which needs interactive `sudo` for apt in this sandbox. That's a pre-existing environment limitation unrelated to this change (same target, same Playwright package version, untouched) — browsers are already cached and `playwright install` without `--with-deps` succeeds cleanly.
- `make test-unit` — **green**: 837/837 tests passed (with `GITHUB_TOKEN` exported per the repo's documented required env vars — 3 `ApplicationApiTests` failed without it, purely due to the missing token, not this change).
- `make test-acceptance` — **could not be run locally.** This sandbox has no `AUTH_DOMAIN`/`AUTH_CLIENT_ID`/`AUTH_CLIENT_SECRET`/`AUTH_AUDIENCE`/`AUTH_USERNAME`/`AUTH_PASSWORD` (or `CYPRESS_*`) Auth0 credentials available, and separately the Playwright browser-dependency install (see above) needs interactive sudo that isn't available here either. Given the change is a single CI-only YAML edit with zero product-code or dependency-graph impact, this should be low risk, but the acceptance suite has not been proven green in this session — please confirm via CI on this PR before merging.

## Test plan

- [x] `dotnet build` (whole solution, green apart from the noted pre-existing sandbox limitation)
- [x] `make test-unit` (837/837 passed)
- [ ] `make test-acceptance` — not run locally (missing Auth0 secrets + sandboxed sudo); will run in CI on this PR