### PR TITLE
feat(zigbee): publish Zigbee network diagnostics to MQTT (haus/zigbee)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test-unit:
 		-v $(CURDIR)/mosquitto.conf:/mosquitto/config/mosquitto.conf eclipse-mosquitto:latest >/dev/null; \
 	until bash -c 'echo > /dev/tcp/127.0.0.1/$(MQTT_TEST_PORT)' 2>/dev/null; do sleep 1; done; \
 	export Mqtt__Server="mqtt://localhost:$(MQTT_TEST_PORT)"; \
+	export Haus__Server="mqtt://localhost:$(MQTT_TEST_PORT)"; \
 	./scripts/run-unit-tests.sh; \
 	status=$$?; \
 	docker rm -f $(MQTT_TEST_CONTAINER) >/dev/null 2>&1 || true; \

--- a/src/Haus.Core.Models/Common/DefaultHausMqttTopics.cs
+++ b/src/Haus.Core.Models/Common/DefaultHausMqttTopics.cs
@@ -6,4 +6,5 @@ public static class DefaultHausMqttTopics
     public const string EventsTopic = "haus/events";
     public const string UnknownTopic = "haus/idk";
     public const string HealthTopic = "haus/health";
+    public const string ZigbeeTopic = "haus/zigbee";
 }

--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeAttributeReportReceivedEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeAttributeReportReceivedEvent.cs
@@ -1,0 +1,22 @@
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeAttributeReportReceivedEvent(
+    ushort NetworkAddress,
+    string? IeeeAddress,
+    ushort ClusterId,
+    ushort AttributeId,
+    byte DataType,
+    ulong RawValue,
+    string? StringValue
+) : IHausEventCreator<ZigbeeAttributeReportReceivedEvent>
+{
+    public const string Type = "zigbee_attribute_report_received";
+
+    public HausEvent<ZigbeeAttributeReportReceivedEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeCommandSentEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeCommandSentEvent.cs
@@ -1,0 +1,15 @@
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeCommandSentEvent(ushort? NetworkAddress, string? IeeeAddress, ushort ClusterId, byte CommandId)
+    : IHausEventCreator<ZigbeeCommandSentEvent>
+{
+    public const string Type = "zigbee_command_sent";
+
+    public HausEvent<ZigbeeCommandSentEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeConnectionStatusChangedEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeConnectionStatusChangedEvent.cs
@@ -1,0 +1,18 @@
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeConnectionStatusChangedEvent(
+    bool IsConnected,
+    ZigbeeNetworkConfigModel? NetworkConfig,
+    string? Reason
+) : IHausEventCreator<ZigbeeConnectionStatusChangedEvent>
+{
+    public const string Type = "zigbee_connection_status_changed";
+
+    public HausEvent<ZigbeeConnectionStatusChangedEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeDeviceInfoDiscoveredEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeDeviceInfoDiscoveredEvent.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeDeviceInfoDiscoveredEvent(
+    string IeeeAddress,
+    string ManufacturerName,
+    string ModelIdentifier,
+    IReadOnlyList<ZigbeeEndpointModel> Endpoints
+) : IHausEventCreator<ZigbeeDeviceInfoDiscoveredEvent>
+{
+    public const string Type = "zigbee_device_info_discovered";
+
+    public HausEvent<ZigbeeDeviceInfoDiscoveredEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeDeviceJoinedEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeDeviceJoinedEvent.cs
@@ -1,0 +1,15 @@
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeDeviceJoinedEvent(string IeeeAddress, ushort NetworkAddress)
+    : IHausEventCreator<ZigbeeDeviceJoinedEvent>
+{
+    public const string Type = "zigbee_device_joined";
+
+    public HausEvent<ZigbeeDeviceJoinedEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeTransportErrorEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeTransportErrorEvent.cs
@@ -1,0 +1,15 @@
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeTransportErrorEvent(string ErrorType, string Message, ushort? NetworkAddress, string? IeeeAddress)
+    : IHausEventCreator<ZigbeeTransportErrorEvent>
+{
+    public const string Type = "zigbee_transport_error";
+
+    public HausEvent<ZigbeeTransportErrorEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/ZigbeeEndpointModel.cs
+++ b/src/Haus.Core.Models/Zigbee/ZigbeeEndpointModel.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace Haus.Core.Models.Zigbee;
+
+public record ZigbeeEndpointModel(byte EndpointId, IReadOnlyList<ushort> InClusters, IReadOnlyList<ushort> OutClusters);

--- a/src/Haus.Core.Models/Zigbee/ZigbeeNetworkConfigModel.cs
+++ b/src/Haus.Core.Models/Zigbee/ZigbeeNetworkConfigModel.cs
@@ -1,0 +1,3 @@
+namespace Haus.Core.Models.Zigbee;
+
+public record ZigbeeNetworkConfigModel(string MacAddress, ushort PanId, byte Channel);

--- a/src/Haus.Mqtt.Client/Settings/HausMqttSettings.cs
+++ b/src/Haus.Mqtt.Client/Settings/HausMqttSettings.cs
@@ -9,4 +9,5 @@ public class HausMqttSettings
     public string CommandsTopic { get; init; } = DefaultHausMqttTopics.CommandsTopic;
     public string UnknownTopic { get; init; } = DefaultHausMqttTopics.UnknownTopic;
     public string HealthTopic { get; init; } = DefaultHausMqttTopics.HealthTopic;
+    public string ZigbeeTopic { get; init; } = DefaultHausMqttTopics.ZigbeeTopic;
 }

--- a/src/Haus.Zigbee.Host/OptionsExtensions.cs
+++ b/src/Haus.Zigbee.Host/OptionsExtensions.cs
@@ -9,4 +9,9 @@ public static class OptionsExtensions
     {
         return options.Value.EventsTopic;
     }
+
+    public static string GetZigbeeTopic(this IOptions<HausOptions> options)
+    {
+        return options.Value.ZigbeeTopic;
+    }
 }

--- a/src/Haus.Zigbee.Host/ServiceCollectionExtensions.cs
+++ b/src/Haus.Zigbee.Host/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<HausLightingToZigbeeMapper>()
             .AddSingleton<ZigbeeInboundRelay>()
             .AddSingleton<ZigbeeOutboundRelay>()
+            .AddSingleton<ZigbeeDiagnosticsPublisher>()
             .AddSingleton<DeviceBackfillService>()
             .Configure<ZigbeeConnectionOptions>(config.GetSection("Zigbee"))
             .AddHausZigbee()

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeDiagnosticsPublisher.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeDiagnosticsPublisher.cs
@@ -1,0 +1,103 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Mqtt.Client;
+using Haus.Zigbee.Coordinator;
+using Haus.Zigbee.Host.Configuration;
+using Haus.Zigbee.Models;
+using Haus.Zigbee.Serial.Frames;
+using Microsoft.Extensions.Options;
+
+namespace Haus.Zigbee.Host.Zigbee.Services;
+
+// Mirrors ZigbeeInboundRelay's shape but publishes raw Zigbee-network visibility onto the
+// haus/zigbee topic, rather than translating Zigbee traffic into Haus domain events -- keeping
+// diagnostics data separate from the domain-event handling ZigbeeInboundRelay owns.
+public class ZigbeeDiagnosticsPublisher(
+    DeviceAddressRegistry addressRegistry,
+    IHausMqttClientFactory mqttClientFactory,
+    IOptions<HausOptions> hausOptions
+)
+{
+    public async Task HandleConnectionStatusChangedAsync(ZigbeeConnectionStatus status)
+    {
+        var networkConfig = status.NetworkConfig is null
+            ? null
+            : new ZigbeeNetworkConfigModel(
+                status.NetworkConfig.MacAddress.ToString(),
+                status.NetworkConfig.PanId,
+                status.NetworkConfig.Channel
+            );
+        await PublishAsync(new ZigbeeConnectionStatusChangedEvent(status.IsConnected, networkConfig, status.Reason));
+    }
+
+    public async Task HandleDeviceJoinedAsync(ZigbeeDeviceJoined joined)
+    {
+        var ieeeAddress = ExternalIdConverter.ToExternalId(joined.IeeeAddress);
+        await PublishAsync(new ZigbeeDeviceJoinedEvent(ieeeAddress, joined.NetworkAddress));
+        await PublishAsync(
+            new ZigbeeDeviceInfoDiscoveredEvent(
+                ieeeAddress,
+                joined.ManufacturerName,
+                joined.ModelIdentifier,
+                joined.Endpoints.Select(ToEndpointModel).ToList()
+            )
+        );
+    }
+
+    public async Task HandleAttributeReportedAsync(ZigbeeAttributeReport report)
+    {
+        var ieeeAddress = ResolveIeeeAddress(report.SourceNwkAddress);
+        await PublishAsync(
+            new ZigbeeAttributeReportReceivedEvent(
+                report.SourceNwkAddress,
+                ieeeAddress,
+                report.ClusterId,
+                report.AttributeId,
+                (byte)report.Value.DataType,
+                report.Value.RawValue,
+                report.Value.StringValue
+            )
+        );
+    }
+
+    public async Task HandleCommandSentAsync(ZigbeeCommandSent sent)
+    {
+        var networkAddress =
+            sent.Destination.Mode == DeconzAddressMode.Nwk ? (ushort?)sent.Destination.ShortAddress : null;
+        var ieeeAddress =
+            sent.Destination.Mode == DeconzAddressMode.Ieee
+                ? ExternalIdConverter.ToExternalId(sent.Destination.IeeeAddress)
+                : ResolveIeeeAddress(sent.Destination.ShortAddress);
+        await PublishAsync(new ZigbeeCommandSentEvent(networkAddress, ieeeAddress, sent.ClusterId, sent.CommandId));
+    }
+
+    public async Task HandleTransportErrorAsync(ZigbeeTransportError error)
+    {
+        var ieeeAddress =
+            error.IeeeAddress is { } address ? ExternalIdConverter.ToExternalId(address)
+            : error.NetworkAddress is { } networkAddress ? ResolveIeeeAddress(networkAddress)
+            : null;
+        await PublishAsync(
+            new ZigbeeTransportErrorEvent(error.ErrorType, error.Message, error.NetworkAddress, ieeeAddress)
+        );
+    }
+
+    private static ZigbeeEndpointModel ToEndpointModel(ZigbeeEndpoint endpoint)
+    {
+        return new ZigbeeEndpointModel(endpoint.EndpointId, endpoint.InClusters, endpoint.OutClusters);
+    }
+
+    private string? ResolveIeeeAddress(ushort networkAddress)
+    {
+        return addressRegistry.TryGetExternalId(networkAddress, out var externalId) ? externalId : null;
+    }
+
+    private async Task PublishAsync<T>(IHausEventCreator<T> creator)
+    {
+        var mqttClient = await mqttClientFactory.CreateClient();
+        await mqttClient.PublishHausEventAsync(creator, hausOptions.GetZigbeeTopic());
+    }
+}

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeHausBridge.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeHausBridge.cs
@@ -17,6 +17,7 @@ public class ZigbeeHausBridge(
     ZigbeeInboundRelay inboundRelay,
     ZigbeeOutboundRelay outboundRelay,
     DeviceBackfillService backfillService,
+    ZigbeeDiagnosticsPublisher diagnosticsPublisher,
     IHausMqttClientFactory hausMqttClientFactory,
     IOptions<HausOptions> hausOptions,
     ILogger<ZigbeeHausBridge> logger
@@ -42,6 +43,9 @@ public class ZigbeeHausBridge(
     {
         coordinator.DeviceJoined += OnDeviceJoined;
         coordinator.AttributeReported += OnAttributeReported;
+        coordinator.ConnectionStatusChanged += OnConnectionStatusChanged;
+        coordinator.CommandSent += OnCommandSent;
+        coordinator.TransportError += OnTransportError;
 
         _hausMqttClient = await hausMqttClientFactory.CreateClient();
         await HausMqttClient.SubscribeAsync(hausOptions.Value.CommandsTopic, HandleHausCommandAsync);
@@ -54,6 +58,9 @@ public class ZigbeeHausBridge(
     {
         coordinator.DeviceJoined -= OnDeviceJoined;
         coordinator.AttributeReported -= OnAttributeReported;
+        coordinator.ConnectionStatusChanged -= OnConnectionStatusChanged;
+        coordinator.CommandSent -= OnCommandSent;
+        coordinator.TransportError -= OnTransportError;
         if (_hausMqttClient != null)
             await _hausMqttClient.DisposeAsync();
         await base.StopAsync(cancellationToken);
@@ -133,6 +140,15 @@ public class ZigbeeHausBridge(
         {
             logger.LogError(e, "Failed to relay device-joined for {@Address}", joined.IeeeAddress);
         }
+
+        try
+        {
+            await diagnosticsPublisher.HandleDeviceJoinedAsync(joined);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to publish diagnostics for device-joined {@Address}", joined.IeeeAddress);
+        }
     }
 
     private async void OnAttributeReported(object? sender, ZigbeeAttributeReport report)
@@ -144,6 +160,55 @@ public class ZigbeeHausBridge(
         catch (Exception e)
         {
             logger.LogError(e, "Failed to relay attribute report from {@Address}", report.SourceNwkAddress);
+        }
+
+        try
+        {
+            await diagnosticsPublisher.HandleAttributeReportedAsync(report);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                e,
+                "Failed to publish diagnostics for attribute report from {@Address}",
+                report.SourceNwkAddress
+            );
+        }
+    }
+
+    private async void OnConnectionStatusChanged(object? sender, ZigbeeConnectionStatus status)
+    {
+        try
+        {
+            await diagnosticsPublisher.HandleConnectionStatusChangedAsync(status);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to publish diagnostics for connection status change");
+        }
+    }
+
+    private async void OnCommandSent(object? sender, ZigbeeCommandSent sent)
+    {
+        try
+        {
+            await diagnosticsPublisher.HandleCommandSentAsync(sent);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to publish diagnostics for command sent");
+        }
+    }
+
+    private async void OnTransportError(object? sender, ZigbeeTransportError error)
+    {
+        try
+        {
+            await diagnosticsPublisher.HandleTransportErrorAsync(error);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to publish diagnostics for transport error");
         }
     }
 }

--- a/src/Haus.Zigbee.Host/appsettings.json
+++ b/src/Haus.Zigbee.Host/appsettings.json
@@ -3,7 +3,8 @@
     "Server": "mqtt://localhost:1883",
     "EventsTopic": "haus/events",
     "CommandsTopic": "haus/commands",
-    "UnknownTopic": "haus/idk"
+    "UnknownTopic": "haus/idk",
+    "ZigbeeTopic": "haus/zigbee"
   },
   "Zigbee": {
     "SerialPort": "/dev/ttyACM0"

--- a/src/Haus.Zigbee/Connection/ApsPollLoop.cs
+++ b/src/Haus.Zigbee/Connection/ApsPollLoop.cs
@@ -2,10 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Zigbee.Serial.Frames;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Haus.Zigbee.Connection;
 
-public class ApsPollLoop(DeconzChannel channel)
+public class ApsPollLoop(DeconzChannel channel, ILogger<ApsPollLoop>? logger = null)
 {
     private const byte ReadIndicationCommandId = 0x17;
     private const byte ReadConfirmCommandId = 0x04;
@@ -14,6 +16,7 @@ public class ApsPollLoop(DeconzChannel channel)
     private const byte ReadConfirmFrameLength = 0x07;
 
     private readonly DeconzChannel _channel = channel;
+    private readonly ILogger<ApsPollLoop> _logger = logger ?? NullLogger<ApsPollLoop>.Instance;
     private byte _sequenceNumber;
 
     public event EventHandler<ApsIndicationReceived>? IndicationReceived;
@@ -40,8 +43,15 @@ public class ApsPollLoop(DeconzChannel channel)
         var response = await _channel.SendAndReceiveAsync(readRequest, token);
 
         var indication = ApsDataIndicationFrameCodec.Decode(response);
-        if (indication is not null)
-            IndicationReceived?.Invoke(this, new ApsIndicationReceived(indication));
+        if (indication is null)
+            return;
+
+        _logger.LogDebug(
+            "Received APS indication from 0x{@SourceNwkAddress:x4} on cluster 0x{@ClusterId:x4}",
+            indication.SourceNwkAddress,
+            indication.ClusterId
+        );
+        IndicationReceived?.Invoke(this, new ApsIndicationReceived(indication));
     }
 
     private async Task DrainConfirmAsync(CancellationToken token)

--- a/src/Haus.Zigbee/Connection/ApsSender.cs
+++ b/src/Haus.Zigbee/Connection/ApsSender.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Haus.Zigbee.Coordinator;
 using Haus.Zigbee.Serial.Frames;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Haus.Zigbee.Connection;
 
@@ -18,6 +20,7 @@ public class ApsSender : IDisposable
     private readonly ApsPollLoop _pollLoop;
     private readonly DeconzChannel _channel;
     private readonly TimeSpan _confirmTimeout;
+    private readonly ILogger<ApsSender> _logger;
     private readonly ConcurrentDictionary<byte, TaskCompletionSource<ApsDataConfirm>> _pendingConfirms = new();
 
     // Interviews for different devices call SendAsync concurrently (each is its own detached
@@ -25,11 +28,17 @@ public class ApsSender : IDisposable
     // needs its own atomic counter rather than a plain field.
     private readonly ByteSequenceCounter _sequenceNumber = new();
 
-    public ApsSender(ApsPollLoop pollLoop, DeconzChannel channel, TimeSpan? confirmTimeout = null)
+    public ApsSender(
+        ApsPollLoop pollLoop,
+        DeconzChannel channel,
+        TimeSpan? confirmTimeout = null,
+        ILogger<ApsSender>? logger = null
+    )
     {
         _pollLoop = pollLoop;
         _channel = channel;
         _confirmTimeout = confirmTimeout ?? DefaultConfirmTimeout;
+        _logger = logger ?? NullLogger<ApsSender>.Instance;
         _pollLoop.ConfirmReceived += OnConfirmReceived;
     }
 
@@ -54,7 +63,21 @@ public class ApsSender : IDisposable
 
             using var timeout = new CancellationTokenSource(_confirmTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, timeout.Token);
-            return await pendingConfirm.Task.WaitAsync(linked.Token);
+            try
+            {
+                var confirm = await pendingConfirm.Task.WaitAsync(linked.Token);
+                _logger.LogDebug("Received confirm for request 0x{@RequestId:x2}", request.RequestId);
+                return confirm;
+            }
+            catch (OperationCanceledException) when (!token.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    "Timed out after {@Timeout} waiting for confirm for request 0x{@RequestId:x2}",
+                    _confirmTimeout,
+                    request.RequestId
+                );
+                throw;
+            }
         }
         finally
         {

--- a/src/Haus.Zigbee/Connection/DeconzChannel.cs
+++ b/src/Haus.Zigbee/Connection/DeconzChannel.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Haus.Zigbee.Serial;
 using Haus.Zigbee.Transport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Haus.Zigbee.Connection;
 
@@ -11,7 +13,7 @@ namespace Haus.Zigbee.Connection;
 // the checksum and SLIP-encodes an outbound command before writing it, then correlates the
 // eventual response by the sequence number that every deCONZ frame carries at byte offset 1.
 // It has no knowledge of what any individual command means.
-public class DeconzChannel(ISerialTransport transport, TimeSpan? roundTripTimeout = null)
+public class DeconzChannel(ISerialTransport transport, TimeSpan? roundTripTimeout = null, ILoggerFactory? loggerFactory = null)
 {
     private const int SequenceNumberIndex = 1;
 
@@ -21,9 +23,11 @@ public class DeconzChannel(ISerialTransport transport, TimeSpan? roundTripTimeou
     private static readonly TimeSpan DefaultRoundTripTimeout = TimeSpan.FromSeconds(5);
 
     private readonly ISerialTransport _transport = transport;
-    private readonly FrameReader _reader = new(transport);
+    private readonly FrameReader _reader = new(transport, loggerFactory?.CreateLogger<FrameReader>());
     private readonly SlipEncoder _encoder = new();
     private readonly TimeSpan _roundTripTimeout = roundTripTimeout ?? DefaultRoundTripTimeout;
+    private readonly ILogger<DeconzChannel> _logger =
+        loggerFactory?.CreateLogger<DeconzChannel>() ?? NullLogger<DeconzChannel>.Instance;
 
     // ZigbeeCoordinator shares one DeconzChannel between its background poll loop and every
     // caller sending a command (APS data requests, permit-join, parameter writes). Without this,
@@ -88,8 +92,16 @@ public class DeconzChannel(ISerialTransport transport, TimeSpan? roundTripTimeou
 
     private async Task<byte[]> RoundTripAsync(byte[] frame, CancellationToken token)
     {
+        var sequenceNumber = frame[SequenceNumberIndex];
+        _logger.LogDebug("Sending frame with sequence number {@SequenceNumber}: {@Frame}", sequenceNumber, frame);
         await _transport.WriteAsync(Encode(frame), token);
-        return await AwaitResponseAsync(frame[SequenceNumberIndex], token);
+        var response = await AwaitResponseAsync(sequenceNumber, token);
+        _logger.LogDebug(
+            "Received response for sequence number {@SequenceNumber}: {@Frame}",
+            sequenceNumber,
+            response
+        );
+        return response;
     }
 
     // The disposed transport eventually faults this task's pending write/read; nothing else

--- a/src/Haus.Zigbee/Connection/FrameReader.cs
+++ b/src/Haus.Zigbee/Connection/FrameReader.cs
@@ -3,18 +3,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using Haus.Zigbee.Serial;
 using Haus.Zigbee.Transport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Haus.Zigbee.Connection;
 
 // Lifecycle/IO plumbing: pulls raw bytes off the transport, reassembles SLIP frames across
 // reads, and surfaces only checksum-valid frames with their trailing checksum stripped.
 // It knows nothing about deCONZ command semantics.
-public class FrameReader(ISerialTransport transport)
+public class FrameReader(ISerialTransport transport, ILogger<FrameReader>? logger = null)
 {
     private const int ReadBufferSize = 256;
+    private const int SequenceNumberIndex = 1;
 
     private readonly ISerialTransport _transport = transport;
     private readonly SlipDecoder _decoder = new();
+    private readonly ILogger<FrameReader> _logger = logger ?? NullLogger<FrameReader>.Instance;
 
     public async Task<IReadOnlyList<byte[]>> ReadFramesAsync(CancellationToken token)
     {
@@ -23,12 +27,25 @@ public class FrameReader(ISerialTransport transport)
         return ValidatedFrames(_decoder.Decode(buffer[..count]));
     }
 
-    private static IReadOnlyList<byte[]> ValidatedFrames(IReadOnlyList<byte[]> decodedFrames)
+    private IReadOnlyList<byte[]> ValidatedFrames(IReadOnlyList<byte[]> decodedFrames)
     {
         var validated = new List<byte[]>();
         foreach (var frame in decodedFrames)
-            if (DeconzChecksum.IsValid(frame))
-                validated.Add(frame[..^2]);
+        {
+            if (!DeconzChecksum.IsValid(frame))
+            {
+                _logger.LogWarning("Discarding frame with an invalid checksum: {@Frame}", frame);
+                continue;
+            }
+
+            var stripped = frame[..^2];
+            _logger.LogDebug(
+                "Read frame with sequence number {@SequenceNumber}: {@Frame}",
+                stripped.Length > SequenceNumberIndex ? stripped[SequenceNumberIndex] : (byte?)null,
+                stripped
+            );
+            validated.Add(stripped);
+        }
         return validated;
     }
 }

--- a/src/Haus.Zigbee/Coordinator/ZigbeeConnectionStatus.cs
+++ b/src/Haus.Zigbee/Coordinator/ZigbeeConnectionStatus.cs
@@ -1,0 +1,3 @@
+namespace Haus.Zigbee.Coordinator;
+
+public record ZigbeeConnectionStatus(bool IsConnected, NetworkConfig? NetworkConfig, string? Reason);

--- a/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
+++ b/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
@@ -245,18 +245,16 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
 
     // A single transient failure must not tear down the long-running loop -- the next poll simply
     // retries. But a failure that means the transport itself is now dead can never self-heal by
-    // retrying in place, so that case is reported back as fatal instead of being swallowed like
-    // every other poll error. Besides our own bounded-timeout dispose (SerialTransportTimeoutException)
-    // and the ObjectDisposedException a real torn-down SerialPort raises on the next call against
-    // it, a physically-unplugged dongle on Linux is also documented to surface as a plain
-    // IOException from SerialPort -- treating it as transient-and-retry-forever would reproduce
-    // this exact PR's root-cause outage class through a different exception type, so it's
-    // classified as fatal too.
-    // Returns the fatal exception when the transport itself is now dead, or null when the poll
-    // either succeeded or hit a transient failure that the next iteration can simply retry past.
-    // The exception is threaded through to HandleTransportFailure rather than being turned into
-    // a ZigbeeTransportError here, so both diagnostics events it raises can be built from the
-    // exact same failure at the exact same call site.
+    // retrying in place, so that case is reported back as fatal (a non-null exception) instead of
+    // being swallowed like every other poll error (which returns null). Besides our own
+    // bounded-timeout dispose (SerialTransportTimeoutException) and the ObjectDisposedException a
+    // real torn-down SerialPort raises on the next call against it, a physically-unplugged dongle
+    // on Linux is also documented to surface as a plain IOException from SerialPort -- treating it
+    // as transient-and-retry-forever would reproduce this exact PR's root-cause outage class
+    // through a different exception type, so it's classified as fatal too. The fatal exception is
+    // threaded through to HandleTransportFailure rather than being turned into a
+    // ZigbeeTransportError here, so both diagnostics events it raises can be built from the exact
+    // same failure at the exact same call site.
     private async Task<Exception?> PollSafelyAsync(ApsPollLoop pollLoop, CancellationToken token)
     {
         try

--- a/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
+++ b/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
@@ -169,11 +169,11 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
     private TransportComponents BuildTransportComponents()
     {
         var transport = _transportFactory();
-        var channel = new DeconzChannel(transport, _channelRoundTripTimeout);
+        var channel = new DeconzChannel(transport, _channelRoundTripTimeout, _loggerFactory);
         var connection = new DeconzConnection(channel);
-        var pollLoop = new ApsPollLoop(channel);
+        var pollLoop = new ApsPollLoop(channel, _loggerFactory.CreateLogger<ApsPollLoop>());
         var permitJoinController = new PermitJoinController(channel);
-        var sender = new ApsSender(pollLoop, channel);
+        var sender = new ApsSender(pollLoop, channel, logger: _loggerFactory.CreateLogger<ApsSender>());
         var commandSender = new CommandSender(sender);
         var attributeReportListener = new AttributeReportListener(pollLoop);
         var deviceInterview = new DeviceInterview(

--- a/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
+++ b/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
@@ -73,6 +73,12 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
 
     public event EventHandler<ZigbeeDeviceJoined>? DeviceJoined;
 
+    public event EventHandler<ZigbeeConnectionStatus>? ConnectionStatusChanged;
+
+    public event EventHandler<ZigbeeCommandSent>? CommandSent;
+
+    public event EventHandler<ZigbeeTransportError>? TransportError;
+
     public async Task ConnectAsync(CancellationToken token)
     {
         var components = AcquireComponentsForConnect();
@@ -92,6 +98,7 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
         }
 
         _isConnected = true;
+        ConnectionStatusChanged?.Invoke(this, new ZigbeeConnectionStatus(true, NetworkConfig, null));
         StartPolling(components);
     }
 
@@ -114,9 +121,19 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
         return CurrentComponents().PermitJoinController.SetPermitJoinAsync(enabled, token);
     }
 
-    public Task<ApsDataConfirm> SendCommandAsync(ZigbeeCommandRequest request, CancellationToken token)
+    public async Task<ApsDataConfirm> SendCommandAsync(ZigbeeCommandRequest request, CancellationToken token)
     {
-        return CurrentComponents().CommandSender.SendCommandAsync(request, token);
+        try
+        {
+            var confirm = await CurrentComponents().CommandSender.SendCommandAsync(request, token);
+            CommandSent?.Invoke(this, new ZigbeeCommandSent(request.Destination, request.ClusterId, request.CommandId));
+            return confirm;
+        }
+        catch (Exception ex)
+        {
+            TransportError?.Invoke(this, BuildTransportError(ex, request.Destination));
+            throw;
+        }
     }
 
     public void Dispose()
@@ -215,9 +232,10 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
     {
         while (!token.IsCancellationRequested)
         {
-            if (!await PollSafelyAsync(components.PollLoop, token))
+            var fatalFailure = await PollSafelyAsync(components.PollLoop, token);
+            if (fatalFailure is not null)
             {
-                HandleTransportFailure(components);
+                HandleTransportFailure(components, fatalFailure);
                 return;
             }
 
@@ -234,27 +252,39 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
     // IOException from SerialPort -- treating it as transient-and-retry-forever would reproduce
     // this exact PR's root-cause outage class through a different exception type, so it's
     // classified as fatal too.
-    private async Task<bool> PollSafelyAsync(ApsPollLoop pollLoop, CancellationToken token)
+    // Returns the fatal exception when the transport itself is now dead, or null when the poll
+    // either succeeded or hit a transient failure that the next iteration can simply retry past.
+    // The exception is threaded through to HandleTransportFailure rather than being turned into
+    // a ZigbeeTransportError here, so both diagnostics events it raises can be built from the
+    // exact same failure at the exact same call site.
+    private async Task<Exception?> PollSafelyAsync(ApsPollLoop pollLoop, CancellationToken token)
     {
         try
         {
             await pollLoop.PollOnceAsync(token);
-            return true;
+            return null;
         }
         catch (OperationCanceledException)
         {
-            return true;
+            return null;
         }
         catch (Exception ex) when (ex is SerialTransportTimeoutException or ObjectDisposedException or IOException)
         {
             _logger.LogWarning(ex, "Zigbee transport failed; marking the connection down so it can reconnect");
-            return false;
+            return ex;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Poll iteration failed, will retry on the next interval");
-            return true;
+            return null;
         }
+    }
+
+    private static ZigbeeTransportError BuildTransportError(Exception ex, ApsDestination destination)
+    {
+        var networkAddress = destination.Mode == DeconzAddressMode.Nwk ? destination.ShortAddress : (ushort?)null;
+        var ieeeAddress = destination.Mode == DeconzAddressMode.Ieee ? destination.IeeeAddress : (IeeeAddress?)null;
+        return new ZigbeeTransportError(ex.GetType().Name, ex.Message, networkAddress, ieeeAddress);
     }
 
     // Takes the exact bundle the failing poll loop was using -- rather than re-reading the
@@ -263,16 +293,20 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
     // whatever _components happens to hold *then* would tear down a perfectly healthy, currently
     // in-use bundle instead of the one that actually failed.
     //
-    // IsConnected is flipped false only once this bundle is fully torn down and
-    // _transportNeedsRebuild is set, not before -- ZigbeeHausBridge's reconnect supervisor reacts
-    // to IsConnected becoming false, so if it observed that flip any earlier it could call
-    // ConnectAsync while cleanup was still in flight on another thread.
-    private void HandleTransportFailure(TransportComponents failedComponents)
+    // IsConnected is flipped false, and TransportError/ConnectionStatusChanged(false, ...) raised,
+    // only once this bundle is fully torn down and _transportNeedsRebuild is set, not before --
+    // ZigbeeHausBridge's reconnect supervisor reacts to IsConnected becoming false, so if it
+    // observed that flip any earlier it could call ConnectAsync while cleanup was still in flight
+    // on another thread.
+    private void HandleTransportFailure(TransportComponents failedComponents, Exception failure)
     {
         MarkFailedForRebuild(failedComponents);
         _pollCancellation?.Dispose();
         _pollCancellation = null;
         _isConnected = false;
+
+        TransportError?.Invoke(this, new ZigbeeTransportError(failure.GetType().Name, failure.Message, null, null));
+        ConnectionStatusChanged?.Invoke(this, new ZigbeeConnectionStatus(false, null, failure.Message));
     }
 
     private void MarkFailedForRebuild(TransportComponents failedComponents)

--- a/src/Haus.Zigbee/IZigbeeCoordinator.cs
+++ b/src/Haus.Zigbee/IZigbeeCoordinator.cs
@@ -32,4 +32,10 @@ public interface IZigbeeCoordinator : IDisposable
     event EventHandler<ZigbeeAttributeReport>? AttributeReported;
 
     event EventHandler<ZigbeeDeviceJoined>? DeviceJoined;
+
+    event EventHandler<ZigbeeConnectionStatus>? ConnectionStatusChanged;
+
+    event EventHandler<ZigbeeCommandSent>? CommandSent;
+
+    event EventHandler<ZigbeeTransportError>? TransportError;
 }

--- a/src/Haus.Zigbee/Models/ZigbeeCommandSent.cs
+++ b/src/Haus.Zigbee/Models/ZigbeeCommandSent.cs
@@ -1,0 +1,5 @@
+using Haus.Zigbee.Serial.Frames;
+
+namespace Haus.Zigbee.Models;
+
+public record ZigbeeCommandSent(ApsDestination Destination, ushort ClusterId, byte CommandId);

--- a/src/Haus.Zigbee/Models/ZigbeeTransportError.cs
+++ b/src/Haus.Zigbee/Models/ZigbeeTransportError.cs
@@ -1,0 +1,3 @@
+namespace Haus.Zigbee.Models;
+
+public record ZigbeeTransportError(string ErrorType, string Message, ushort? NetworkAddress, IeeeAddress? IeeeAddress);

--- a/src/Haus.Zigbee/ServiceCollectionExtensions.cs
+++ b/src/Haus.Zigbee/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Haus.Zigbee.Coordinator;
 using Haus.Zigbee.Transport;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Haus.Zigbee;
@@ -22,8 +23,17 @@ public static class ServiceCollectionExtensions
     private static ISerialTransport CreateTransport(IServiceProvider provider)
     {
         var options = provider.GetRequiredService<IOptions<ZigbeeConnectionOptions>>().Value;
+        var loggerFactory = provider.GetService<ILoggerFactory>();
         return string.IsNullOrEmpty(options.TcpHost)
-            ? new SerialPortTransport(options.SerialPort, options.BaudRate)
-            : new TcpSerialTransport(options.TcpHost, options.TcpPort);
+            ? new SerialPortTransport(
+                options.SerialPort,
+                options.BaudRate,
+                loggerFactory?.CreateLogger<SerialPortTransport>()
+            )
+            : new TcpSerialTransport(
+                options.TcpHost,
+                options.TcpPort,
+                loggerFactory?.CreateLogger<TcpSerialTransport>()
+            );
     }
 }

--- a/src/Haus.Zigbee/Transport/SerialPortTransport.cs
+++ b/src/Haus.Zigbee/Transport/SerialPortTransport.cs
@@ -1,34 +1,67 @@
 using System;
+using System.IO;
 using System.IO.Ports;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Haus.Zigbee.Transport;
 
 // The real seam adapter over System.IO.Ports.SerialPort. It has no way to be unit-tested
 // without physical hardware, so it deliberately carries no logic beyond delegating to the
 // underlying port; every layer above it is exercised through ISerialTransport doubles instead.
-public class SerialPortTransport(string portName, int baudRate) : ISerialTransport
+public class SerialPortTransport(string portName, int baudRate, ILogger<SerialPortTransport>? logger = null)
+    : ISerialTransport
 {
     private readonly SerialPort _serialPort = new(portName, baudRate);
+    private readonly ILogger<SerialPortTransport> _logger = logger ?? NullLogger<SerialPortTransport>.Instance;
 
     public Task OpenAsync(CancellationToken token)
     {
         _serialPort.Open();
+        _logger.LogInformation("Opened serial port {@PortName} at {@BaudRate} baud", portName, baudRate);
         return Task.CompletedTask;
     }
 
     public Task CloseAsync(CancellationToken token)
     {
         _serialPort.Close();
+        _logger.LogInformation("Closed serial port {@PortName}", portName);
         return Task.CompletedTask;
     }
 
     public Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token) =>
-        _serialPort.BaseStream.WriteAsync(buffer, token).AsTask();
+        WithConnectionErrorLogging(() => _serialPort.BaseStream.WriteAsync(buffer, token).AsTask());
 
     public Task<int> ReadAsync(Memory<byte> buffer, CancellationToken token) =>
-        _serialPort.BaseStream.ReadAsync(buffer, token).AsTask();
+        WithConnectionErrorLogging(() => _serialPort.BaseStream.ReadAsync(buffer, token).AsTask());
 
     public void Dispose() => _serialPort.Dispose();
+
+    private async Task WithConnectionErrorLogging(Func<Task> operation)
+    {
+        try
+        {
+            await operation();
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Serial port {@PortName} failed", portName);
+            throw;
+        }
+    }
+
+    private async Task<int> WithConnectionErrorLogging(Func<Task<int>> operation)
+    {
+        try
+        {
+            return await operation();
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Serial port {@PortName} failed", portName);
+            throw;
+        }
+    }
 }

--- a/src/Haus.Zigbee/Transport/TcpSerialTransport.cs
+++ b/src/Haus.Zigbee/Transport/TcpSerialTransport.cs
@@ -1,36 +1,68 @@
 using System;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Haus.Zigbee.Transport;
 
 // A second ISerialTransport implementation for environments with no physical deCONZ dongle
 // attached (CI, containers, most dev machines): connects to a TCP endpoint that speaks the exact
 // same SLIP+deCONZ byte protocol a real serial line would carry, typically a simulator.
-public class TcpSerialTransport(string host, int port) : ISerialTransport
+public class TcpSerialTransport(string host, int port, ILogger<TcpSerialTransport>? logger = null) : ISerialTransport
 {
+    private readonly ILogger<TcpSerialTransport> _logger = logger ?? NullLogger<TcpSerialTransport>.Instance;
     private TcpClient? _client;
 
     public async Task OpenAsync(CancellationToken token)
     {
         _client = new TcpClient();
         await _client.ConnectAsync(host, port, token);
+        _logger.LogInformation("Connected to {@Host}:{@Port}", host, port);
     }
 
     public Task CloseAsync(CancellationToken token)
     {
         _client?.Close();
+        _logger.LogInformation("Closed connection to {@Host}:{@Port}", host, port);
         return Task.CompletedTask;
     }
 
     public Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token) =>
-        RequireOpenClient().GetStream().WriteAsync(buffer, token).AsTask();
+        WithConnectionErrorLogging(() => RequireOpenClient().GetStream().WriteAsync(buffer, token).AsTask());
 
     public Task<int> ReadAsync(Memory<byte> buffer, CancellationToken token) =>
-        RequireOpenClient().GetStream().ReadAsync(buffer, token).AsTask();
+        WithConnectionErrorLogging(() => RequireOpenClient().GetStream().ReadAsync(buffer, token).AsTask());
 
     public void Dispose() => _client?.Dispose();
+
+    private async Task WithConnectionErrorLogging(Func<Task> operation)
+    {
+        try
+        {
+            await operation();
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Connection to {@Host}:{@Port} failed", host, port);
+            throw;
+        }
+    }
+
+    private async Task<int> WithConnectionErrorLogging(Func<Task<int>> operation)
+    {
+        try
+        {
+            return await operation();
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Connection to {@Host}:{@Port} failed", host, port);
+            throw;
+        }
+    }
 
     private TcpClient RequireOpenClient() =>
         _client ?? throw new InvalidOperationException("OpenAsync must be called before reading or writing.");

--- a/tests/Haus.Zigbee.Host.Tests/Support/ConfigurationFactory.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/ConfigurationFactory.cs
@@ -33,6 +33,10 @@ public static class ConfigurationFactory
                     new("Haus:ZigbeeTopic", hausZigbeeTopic),
                 }.AsReadOnly()
             )
+            // Lets CI's disposable-broker port (exported as Haus__Server, see Makefile's test-unit
+            // target) override the in-memory default below, the same way Haus.Web.Host.Tests picks
+            // up Mqtt__Server through its WebApplicationFactory's standard configuration layering.
+            .AddEnvironmentVariables()
             .Build();
     }
 }

--- a/tests/Haus.Zigbee.Host.Tests/Support/ConfigurationFactory.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/ConfigurationFactory.cs
@@ -9,12 +9,15 @@ public static class ConfigurationFactory
     public const string DefaultHausCommandsTopic = Defaults.HausOptions.CommandsTopic;
     public const string DefaultHausUnknownTopic = Defaults.HausOptions.UnknownTopic;
     public const string DefaultHausHealthTopic = Defaults.HausOptions.HealthTopic;
+    public const string DefaultHausZigbeeTopic = Defaults.HausOptions.ZigbeeTopic;
 
     public static IConfiguration CreateConfig(
         string hausEventsTopic = DefaultHausEventsTopic,
         string hausCommandsTopic = DefaultHausCommandsTopic,
         string hausUnknownTopic = DefaultHausUnknownTopic,
-        string hausHealthTopic = DefaultHausHealthTopic
+        string hausHealthTopic = DefaultHausHealthTopic,
+        string hausZigbeeTopic = DefaultHausZigbeeTopic,
+        string? hausServer = null
     )
     {
         return new ConfigurationBuilder()
@@ -22,11 +25,12 @@ public static class ConfigurationFactory
                 new List<KeyValuePair<string, string?>>
                 {
                     new("Zigbee:SerialPort", "/dev/ttyACM0"),
-                    new("Haus:Server", "mqtt://localhost:1883"),
+                    new("Haus:Server", hausServer ?? "mqtt://localhost:1883"),
                     new("Haus:EventsTopic", hausEventsTopic),
                     new("Haus:CommandsTopic", hausCommandsTopic),
                     new("Haus:UnknownTopic", hausUnknownTopic),
                     new("Haus:Health", hausHealthTopic),
+                    new("Haus:ZigbeeTopic", hausZigbeeTopic),
                 }.AsReadOnly()
             )
             .Build();

--- a/tests/Haus.Zigbee.Host.Tests/Support/Defaults.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/Defaults.cs
@@ -10,5 +10,6 @@ public static class Defaults
         public const string CommandsTopic = DefaultHausMqttTopics.CommandsTopic;
         public const string UnknownTopic = DefaultHausMqttTopics.UnknownTopic;
         public const string HealthTopic = DefaultHausMqttTopics.HealthTopic;
+        public const string ZigbeeTopic = DefaultHausMqttTopics.ZigbeeTopic;
     }
 }

--- a/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
@@ -25,6 +25,9 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
 
     public event System.EventHandler<ZigbeeAttributeReport>? AttributeReported;
     public event System.EventHandler<ZigbeeDeviceJoined>? DeviceJoined;
+    public event System.EventHandler<ZigbeeConnectionStatus>? ConnectionStatusChanged;
+    public event System.EventHandler<ZigbeeCommandSent>? CommandSent;
+    public event System.EventHandler<ZigbeeTransportError>? TransportError;
 
     public Task ConnectAsync(CancellationToken token)
     {
@@ -69,6 +72,21 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public void RaiseAttributeReported(ZigbeeAttributeReport report)
     {
         AttributeReported?.Invoke(this, report);
+    }
+
+    public void RaiseConnectionStatusChanged(ZigbeeConnectionStatus status)
+    {
+        ConnectionStatusChanged?.Invoke(this, status);
+    }
+
+    public void RaiseCommandSent(ZigbeeCommandSent sent)
+    {
+        CommandSent?.Invoke(this, sent);
+    }
+
+    public void RaiseTransportError(ZigbeeTransportError error)
+    {
+        TransportError?.Invoke(this, error);
     }
 
     public void Dispose() { }

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeDiagnosticsPublisherRealBrokerTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeDiagnosticsPublisherRealBrokerTests.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Mqtt.Client;
+using Haus.Testing.Support;
+using Haus.Zigbee.Coordinator;
+using Haus.Zigbee.Host.Tests.Support;
+using Haus.Zigbee.Host.Zigbee.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Haus.Zigbee.Host.Tests.Zigbee.Services;
+
+// Unlike ZigbeeDiagnosticsPublisherTests, this exercises the publisher against a real MQTT broker
+// (no FakeMqttClientFactory) -- the same real-broker pattern Haus.Web.Host.Tests relies on, backed
+// by the disposable broker make test-unit stands up on Haus__Server (see ConfigurationFactory).
+public class ZigbeeDiagnosticsPublisherRealBrokerTests : IAsyncLifetime
+{
+    private IHausMqttClient? _hausMqttClient;
+    private ZigbeeDiagnosticsPublisher? _publisher;
+
+    public async Task InitializeAsync()
+    {
+        var provider = ServiceProviderFactory.Create(configuration: ConfigurationFactory.CreateConfig());
+        var mqttClientFactory = provider.GetRequiredService<IHausMqttClientFactory>();
+        _hausMqttClient = await mqttClientFactory.CreateClient();
+
+        _publisher = provider.GetRequiredService<ZigbeeDiagnosticsPublisher>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _hausMqttClient!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task HandleConnectionStatusChangedAsync_RealBroker_RoundTripsOverHausZigbeeTopic()
+    {
+        ZigbeeConnectionStatusChangedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeConnectionStatusChangedEvent>(
+            ZigbeeConnectionStatusChangedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+
+        // MQTTnet's managed client applies a SubscribeAsync call asynchronously in the background
+        // rather than confirming it against the broker before returning, so a single publish
+        // immediately after subscribing can race ahead of the subscription actually landing.
+        // Re-publishing on every retry (rather than once before the loop) closes that window.
+        await Eventually.AssertAsync(async () =>
+        {
+            await _publisher!.HandleConnectionStatusChangedAsync(new ZigbeeConnectionStatus(true, null, null));
+            Assert.NotNull(published);
+            Assert.True(published!.IsConnected);
+        });
+    }
+}

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeDiagnosticsPublisherTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeDiagnosticsPublisherTests.cs
@@ -1,0 +1,264 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Mqtt.Client;
+using Haus.Testing.Support;
+using Haus.Testing.Support.Fakes;
+using Haus.Zigbee.Coordinator;
+using Haus.Zigbee.Host.Tests.Support;
+using Haus.Zigbee.Host.Zigbee;
+using Haus.Zigbee.Host.Zigbee.Services;
+using Haus.Zigbee.Models;
+using Haus.Zigbee.Serial.Frames;
+using Haus.Zigbee.Zcl;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Haus.Zigbee.Host.Tests.Zigbee.Services;
+
+public class ZigbeeDiagnosticsPublisherTests : IAsyncLifetime
+{
+    private IHausMqttClient? _hausMqttClient;
+    private DeviceAddressRegistry? _addressRegistry;
+    private ZigbeeDiagnosticsPublisher? _publisher;
+
+    public async Task InitializeAsync()
+    {
+        var provider = ServiceProviderFactory.Create(mqttFactory: new FakeMqttClientFactory());
+        var mqttClientFactory = provider.GetRequiredService<IHausMqttClientFactory>();
+        _hausMqttClient = await mqttClientFactory.CreateClient();
+        _addressRegistry = provider.GetRequiredService<DeviceAddressRegistry>();
+
+        _publisher = provider.GetRequiredService<ZigbeeDiagnosticsPublisher>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _hausMqttClient!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task HandleConnectionStatusChangedAsync_Connected_PublishesConnectedStatus()
+    {
+        ZigbeeConnectionStatusChangedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeConnectionStatusChangedEvent>(
+            ZigbeeConnectionStatusChangedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var networkConfig = new NetworkConfig(new IeeeAddress(0x00124b0001aabbcc), 0x1a62, 0x0f);
+        var status = new ZigbeeConnectionStatus(true, networkConfig, null);
+
+        await _publisher!.HandleConnectionStatusChangedAsync(status);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.True(published!.IsConnected);
+            Assert.Equal("0x00124b0001aabbcc", published.NetworkConfig!.MacAddress);
+            Assert.Equal((ushort)0x1a62, published.NetworkConfig.PanId);
+            Assert.Equal((byte)0x0f, published.NetworkConfig.Channel);
+            Assert.Null(published.Reason);
+        });
+    }
+
+    [Fact]
+    public async Task HandleConnectionStatusChangedAsync_Disconnected_PublishesDisconnectedStatusWithReason()
+    {
+        ZigbeeConnectionStatusChangedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeConnectionStatusChangedEvent>(
+            ZigbeeConnectionStatusChangedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var status = new ZigbeeConnectionStatus(false, null, "dongle unplugged");
+
+        await _publisher!.HandleConnectionStatusChangedAsync(status);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.False(published!.IsConnected);
+            Assert.Null(published.NetworkConfig);
+            Assert.Equal("dongle unplugged", published.Reason);
+        });
+    }
+
+    [Fact]
+    public async Task HandleDeviceJoinedAsync_PublishesDeviceJoinedEvent()
+    {
+        ZigbeeDeviceJoinedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeDeviceJoinedEvent>(
+            ZigbeeDeviceJoinedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var address = new IeeeAddress(0x00124b0001aabbcc);
+        var joined = new ZigbeeDeviceJoined(address, 0x1a2b, [], "acme", "widget");
+
+        await _publisher!.HandleDeviceJoinedAsync(joined);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Equal("0x00124b0001aabbcc", published!.IeeeAddress);
+            Assert.Equal((ushort)0x1a2b, published.NetworkAddress);
+        });
+    }
+
+    [Fact]
+    public async Task HandleDeviceJoinedAsync_PublishesDeviceInfoDiscoveredEvent()
+    {
+        ZigbeeDeviceInfoDiscoveredEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeDeviceInfoDiscoveredEvent>(
+            ZigbeeDeviceInfoDiscoveredEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var address = new IeeeAddress(0x00124b0001aabbcc);
+        var endpoints = new List<ZigbeeEndpoint> { new(0x01, 0x0104, 0x0000, [0x0000, 0x0006], [0x0019]) };
+        var joined = new ZigbeeDeviceJoined(address, 0x1a2b, endpoints, "acme", "widget");
+
+        await _publisher!.HandleDeviceJoinedAsync(joined);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Equal("0x00124b0001aabbcc", published!.IeeeAddress);
+            Assert.Equal("acme", published.ManufacturerName);
+            Assert.Equal("widget", published.ModelIdentifier);
+            var endpoint = Assert.Single(published.Endpoints);
+            Assert.Equal((byte)0x01, endpoint.EndpointId);
+            Assert.Equal(new ushort[] { 0x0000, 0x0006 }, endpoint.InClusters);
+            Assert.Equal(new ushort[] { 0x0019 }, endpoint.OutClusters);
+        });
+    }
+
+    [Fact]
+    public async Task HandleAttributeReportedAsync_KnownDevice_PublishesReportWithResolvedIeeeAddress()
+    {
+        _addressRegistry!.Register(0x1a2b, "0x00124b0001aabbcc");
+        ZigbeeAttributeReportReceivedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeAttributeReportReceivedEvent>(
+            ZigbeeAttributeReportReceivedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var report = new ZigbeeAttributeReport(
+            0x1a2b,
+            1,
+            0x0402,
+            0x0000,
+            new ZclAttributeValue(ZclDataType.Int16, 2100)
+        );
+
+        await _publisher!.HandleAttributeReportedAsync(report);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Equal((ushort)0x1a2b, published!.NetworkAddress);
+            Assert.Equal("0x00124b0001aabbcc", published.IeeeAddress);
+            Assert.Equal((ushort)0x0402, published.ClusterId);
+            Assert.Equal((ushort)0x0000, published.AttributeId);
+            Assert.Equal((byte)ZclDataType.Int16, published.DataType);
+            Assert.Equal(2100ul, published.RawValue);
+        });
+    }
+
+    [Fact]
+    public async Task HandleAttributeReportedAsync_UnknownDevice_PublishesReportWithNoIeeeAddress()
+    {
+        ZigbeeAttributeReportReceivedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeAttributeReportReceivedEvent>(
+            ZigbeeAttributeReportReceivedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var report = new ZigbeeAttributeReport(
+            0x9999,
+            1,
+            0x0402,
+            0x0000,
+            new ZclAttributeValue(ZclDataType.Int16, 2100)
+        );
+
+        await _publisher!.HandleAttributeReportedAsync(report);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Null(published!.IeeeAddress);
+        });
+    }
+
+    [Fact]
+    public async Task HandleCommandSentAsync_IeeeDestination_PublishesResolvedTarget()
+    {
+        ZigbeeCommandSentEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeCommandSentEvent>(
+            ZigbeeCommandSentEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var destination = ApsDestination.Ieee(new IeeeAddress(0x00124b0001aabbcc), 0x01);
+        var sent = new ZigbeeCommandSent(destination, 0x0006, 0x01);
+
+        await _publisher!.HandleCommandSentAsync(sent);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Equal("0x00124b0001aabbcc", published!.IeeeAddress);
+            Assert.Null(published.NetworkAddress);
+            Assert.Equal((ushort)0x0006, published.ClusterId);
+            Assert.Equal((byte)0x01, published.CommandId);
+        });
+    }
+
+    [Fact]
+    public async Task HandleCommandSentAsync_NwkDestination_PublishesResolvedNetworkAddress()
+    {
+        ZigbeeCommandSentEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeCommandSentEvent>(
+            ZigbeeCommandSentEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var destination = ApsDestination.Nwk(0x1a2b, 0x01);
+        var sent = new ZigbeeCommandSent(destination, 0x0006, 0x01);
+
+        await _publisher!.HandleCommandSentAsync(sent);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Equal((ushort)0x1a2b, published!.NetworkAddress);
+            Assert.Null(published.IeeeAddress);
+        });
+    }
+
+    [Fact]
+    public async Task HandleTransportErrorAsync_PublishesErrorTypeAndMessage()
+    {
+        ZigbeeTransportErrorEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeTransportErrorEvent>(
+            ZigbeeTransportErrorEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+        var error = new ZigbeeTransportError("IOException", "Simulated serial read failure", null, null);
+
+        await _publisher!.HandleTransportErrorAsync(error);
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(published);
+            Assert.Equal("IOException", published!.ErrorType);
+            Assert.Equal("Simulated serial read failure", published.Message);
+            Assert.Null(published.NetworkAddress);
+            Assert.Null(published.IeeeAddress);
+        });
+    }
+}

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeHausBridgeTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeHausBridgeTests.cs
@@ -2,12 +2,17 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Haus.Core.Models.Common;
 using Haus.Core.Models.Discovery;
+using Haus.Core.Models.Zigbee.Events;
 using Haus.Mqtt.Client;
 using Haus.Testing.Support;
 using Haus.Testing.Support.Fakes;
+using Haus.Zigbee.Coordinator;
 using Haus.Zigbee.Host.Tests.Support;
 using Haus.Zigbee.Host.Zigbee.Services;
+using Haus.Zigbee.Models;
+using Haus.Zigbee.Serial.Frames;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -16,6 +21,139 @@ namespace Haus.Zigbee.Host.Tests.Zigbee.Services;
 
 public class ZigbeeHausBridgeTests
 {
+    [Fact]
+    public async Task WhenCoordinatorConnectionStatusChangesThenTheDiagnosticsPublisherReceivesIt()
+    {
+        var coordinator = new FakeZigbeeCoordinator();
+        var provider = ServiceProviderFactory.Create(
+            mqttFactory: new FakeMqttClientFactory(),
+            zigbeeCoordinator: coordinator
+        );
+        var bridge = ResolveBridge(provider);
+        await bridge.StartAsync(CancellationToken.None);
+        var mqttClient = await provider.GetRequiredService<IHausMqttClientFactory>().CreateClient();
+        ZigbeeConnectionStatusChangedEvent? published = null;
+        await mqttClient.SubscribeToHausEventsAsync<ZigbeeConnectionStatusChangedEvent>(
+            ZigbeeConnectionStatusChangedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+
+        coordinator.RaiseConnectionStatusChanged(new ZigbeeConnectionStatus(true, null, null));
+
+        Eventually.Assert(() => Assert.True(published?.IsConnected));
+
+        await bridge.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WhenCoordinatorCommandSentThenTheDiagnosticsPublisherReceivesIt()
+    {
+        var coordinator = new FakeZigbeeCoordinator();
+        var provider = ServiceProviderFactory.Create(
+            mqttFactory: new FakeMqttClientFactory(),
+            zigbeeCoordinator: coordinator
+        );
+        var bridge = ResolveBridge(provider);
+        await bridge.StartAsync(CancellationToken.None);
+        var mqttClient = await provider.GetRequiredService<IHausMqttClientFactory>().CreateClient();
+        ZigbeeCommandSentEvent? published = null;
+        await mqttClient.SubscribeToHausEventsAsync<ZigbeeCommandSentEvent>(
+            ZigbeeCommandSentEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+
+        coordinator.RaiseCommandSent(new ZigbeeCommandSent(ApsDestination.Nwk(0x1234, 0x01), 0x0006, 0x01));
+
+        Eventually.Assert(() => Assert.Equal((ushort)0x1234, published?.NetworkAddress));
+
+        await bridge.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WhenCoordinatorTransportErrorThenTheDiagnosticsPublisherReceivesIt()
+    {
+        var coordinator = new FakeZigbeeCoordinator();
+        var provider = ServiceProviderFactory.Create(
+            mqttFactory: new FakeMqttClientFactory(),
+            zigbeeCoordinator: coordinator
+        );
+        var bridge = ResolveBridge(provider);
+        await bridge.StartAsync(CancellationToken.None);
+        var mqttClient = await provider.GetRequiredService<IHausMqttClientFactory>().CreateClient();
+        ZigbeeTransportErrorEvent? published = null;
+        await mqttClient.SubscribeToHausEventsAsync<ZigbeeTransportErrorEvent>(
+            ZigbeeTransportErrorEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+
+        coordinator.RaiseTransportError(new ZigbeeTransportError("IOException", "boom", null, null));
+
+        Eventually.Assert(() => Assert.Equal("boom", published?.Message));
+
+        await bridge.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WhenDeviceJoinsThenTheDiagnosticsPublisherAlsoReceivesIt()
+    {
+        var coordinator = new FakeZigbeeCoordinator();
+        var provider = ServiceProviderFactory.Create(
+            mqttFactory: new FakeMqttClientFactory(),
+            zigbeeCoordinator: coordinator
+        );
+        var bridge = ResolveBridge(provider);
+        await bridge.StartAsync(CancellationToken.None);
+        var mqttClient = await provider.GetRequiredService<IHausMqttClientFactory>().CreateClient();
+        ZigbeeDeviceJoinedEvent? published = null;
+        await mqttClient.SubscribeToHausEventsAsync<ZigbeeDeviceJoinedEvent>(
+            ZigbeeDeviceJoinedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+
+        coordinator.RaiseDeviceJoined(new ZigbeeDeviceJoined(new IeeeAddress(1), 0x1234, [], "acme", "widget"));
+
+        Eventually.Assert(() => Assert.Equal((ushort)0x1234, published?.NetworkAddress));
+
+        await bridge.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WhenAttributeReportedThenTheDiagnosticsPublisherAlsoReceivesIt()
+    {
+        var coordinator = new FakeZigbeeCoordinator();
+        var provider = ServiceProviderFactory.Create(
+            mqttFactory: new FakeMqttClientFactory(),
+            zigbeeCoordinator: coordinator
+        );
+        var bridge = ResolveBridge(provider);
+        await bridge.StartAsync(CancellationToken.None);
+        var mqttClient = await provider.GetRequiredService<IHausMqttClientFactory>().CreateClient();
+        ZigbeeAttributeReportReceivedEvent? published = null;
+        await mqttClient.SubscribeToHausEventsAsync<ZigbeeAttributeReportReceivedEvent>(
+            ZigbeeAttributeReportReceivedEvent.Type,
+            e => published = e.Payload,
+            DefaultHausMqttTopics.ZigbeeTopic
+        );
+
+        coordinator.RaiseAttributeReported(
+            new ZigbeeAttributeReport(
+                0x1234,
+                1,
+                0x0402,
+                0x0000,
+                new Haus.Zigbee.Zcl.ZclAttributeValue(Haus.Zigbee.Zcl.ZclDataType.Int16, 100)
+            )
+        );
+
+        Eventually.Assert(() => Assert.Equal((ushort)0x1234, published?.NetworkAddress));
+
+        await bridge.StopAsync(CancellationToken.None);
+    }
+
     [Fact]
     public async Task HandleHausCommand_OutboundRelayThrows_SubsequentCommandsStillGetHandled()
     {

--- a/tests/Haus.Zigbee.Tests/Connection/ApsPollLoopTests.cs
+++ b/tests/Haus.Zigbee.Tests/Connection/ApsPollLoopTests.cs
@@ -6,6 +6,8 @@ using Haus.Zigbee.Connection;
 using Haus.Zigbee.Serial;
 using Haus.Zigbee.Serial.Frames;
 using Haus.Zigbee.Tests.Coordinator;
+using Haus.Zigbee.Tests.Support;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Tests.Connection;
@@ -20,11 +22,28 @@ public class ApsPollLoopTests
     private const byte NwkAddressMode = 0x02;
 
     private readonly ScriptedSerialTransport _transport = new();
+    private readonly CapturingLoggerFactory _loggerFactory = new();
     private readonly ApsPollLoop _loop;
 
     public ApsPollLoopTests()
     {
-        _loop = new ApsPollLoop(new DeconzChannel(_transport));
+        _loop = new ApsPollLoop(new DeconzChannel(_transport), _loggerFactory.CreateLogger<ApsPollLoop>());
+    }
+
+    [Fact]
+    public async Task WhenAnIndicationIsReadThenItIsLoggedAtDebugLevelWithTheSourceAddress()
+    {
+        _transport.QueueResponse(
+            DeconzFrames.Framed(DeviceStateResponse(sequenceNumber: 0, deviceState: IndicationAvailable))
+        );
+        _transport.QueueResponse(DeconzFrames.Framed(IndicationResponse(sequenceNumber: 1)));
+
+        await _loop.PollOnceAsync(CancellationToken.None);
+
+        Assert.Contains(
+            _loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Debug && entry.Message.Contains("0x1234")
+        );
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Tests/Connection/ApsSenderTests.cs
+++ b/tests/Haus.Zigbee.Tests/Connection/ApsSenderTests.cs
@@ -7,7 +7,9 @@ using Haus.Zigbee.Connection;
 using Haus.Zigbee.Serial;
 using Haus.Zigbee.Serial.Frames;
 using Haus.Zigbee.Tests.Coordinator;
+using Haus.Zigbee.Tests.Support;
 using Haus.Zigbee.Transport;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Tests.Connection;
@@ -98,6 +100,27 @@ public class ApsSenderTests
 
         Assert.Same(sendTask, completed);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sendTask);
+    }
+
+    [Fact]
+    public async Task WhenNoConfirmEverArrivesThenAWarningIsLoggedWithTheRequestId()
+    {
+        var loggerFactory = new CapturingLoggerFactory();
+        var timingOutSender = new ApsSender(
+            _pollLoop,
+            new DeconzChannel(_senderTransport),
+            confirmTimeout: TimeSpan.FromMilliseconds(50),
+            logger: loggerFactory.CreateLogger<ApsSender>()
+        );
+        _senderTransport.QueueResponse(DeconzFrames.Framed(DeconzAck(sequenceNumber: 0)));
+
+        var sendTask = timingOutSender.SendAsync(Request(requestId: 0x42), CancellationToken.None);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sendTask);
+
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Warning && entry.Message.Contains("0x42")
+        );
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Tests/Connection/DeconzChannelTests.cs
+++ b/tests/Haus.Zigbee.Tests/Connection/DeconzChannelTests.cs
@@ -22,7 +22,7 @@ public class DeconzChannelTests
 
     public DeconzChannelTests()
     {
-        _channel = new DeconzChannel(_transport, _loggerFactory);
+        _channel = new DeconzChannel(_transport, loggerFactory: _loggerFactory);
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Tests/Connection/DeconzChannelTests.cs
+++ b/tests/Haus.Zigbee.Tests/Connection/DeconzChannelTests.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Zigbee.Connection;
 using Haus.Zigbee.Serial;
 using Haus.Zigbee.Tests.Coordinator;
+using Haus.Zigbee.Tests.Support;
 using Haus.Zigbee.Tests.Transport;
 using Haus.Zigbee.Transport;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Tests.Connection;
@@ -14,11 +17,26 @@ namespace Haus.Zigbee.Tests.Connection;
 public class DeconzChannelTests
 {
     private readonly FakeSerialTransport _transport = new();
+    private readonly CapturingLoggerFactory _loggerFactory = new();
     private readonly DeconzChannel _channel;
 
     public DeconzChannelTests()
     {
-        _channel = new DeconzChannel(_transport);
+        _channel = new DeconzChannel(_transport, _loggerFactory);
+    }
+
+    [Fact]
+    public async Task WhenSendingAFrameThenTheSendAndReceiveAreLoggedAtDebugLevel()
+    {
+        var command = new byte[] { 0x0A, 0x05, 0x01 };
+        _transport.FeedIncoming(DeconzFrames.Framed(new byte[] { 0x0A, 0x05, 0x00 }));
+
+        await _channel.SendAndReceiveAsync(command, CancellationToken.None);
+
+        var debugEntries = _loggerFactory
+            .Entries.Where(entry => entry.Category == typeof(DeconzChannel).FullName && entry.Level == LogLevel.Debug)
+            .ToList();
+        Assert.True(debugEntries.Count >= 2);
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Tests/Connection/FrameReaderTests.cs
+++ b/tests/Haus.Zigbee.Tests/Connection/FrameReaderTests.cs
@@ -4,7 +4,9 @@ using System.Threading.Tasks;
 using Haus.Zigbee.Connection;
 using Haus.Zigbee.Serial;
 using Haus.Zigbee.Tests.Coordinator;
+using Haus.Zigbee.Tests.Support;
 using Haus.Zigbee.Tests.Transport;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Tests.Connection;
@@ -12,11 +14,12 @@ namespace Haus.Zigbee.Tests.Connection;
 public class FrameReaderTests
 {
     private readonly FakeSerialTransport _transport = new();
+    private readonly CapturingLoggerFactory _loggerFactory = new();
     private readonly FrameReader _reader;
 
     public FrameReaderTests()
     {
-        _reader = new FrameReader(_transport);
+        _reader = new FrameReader(_transport, _loggerFactory.CreateLogger<FrameReader>());
     }
 
     [Fact]
@@ -49,6 +52,26 @@ public class FrameReaderTests
         var frames = await _reader.ReadFramesAsync(CancellationToken.None);
 
         Assert.Empty(frames);
+    }
+
+    [Fact]
+    public async Task WhenAFrameFailsChecksumValidationThenAWarningIsLogged()
+    {
+        _transport.FeedIncoming(FramedWithCorruptedChecksum(new byte[] { 0x07, 0x03, 0xAA }));
+
+        await _reader.ReadFramesAsync(CancellationToken.None);
+
+        Assert.Contains(_loggerFactory.Entries, entry => entry.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task WhenAValidFrameArrivesThenItIsLoggedAtDebugLevel()
+    {
+        _transport.FeedIncoming(DeconzFrames.Framed(new byte[] { 0x07, 0x03, 0xAA }));
+
+        await _reader.ReadFramesAsync(CancellationToken.None);
+
+        Assert.Contains(_loggerFactory.Entries, entry => entry.Level == LogLevel.Debug);
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Tests/Coordinator/FailingCommandTransport.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/FailingCommandTransport.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Zigbee.Serial;
+using Haus.Zigbee.Transport;
+
+namespace Haus.Zigbee.Tests.Coordinator;
+
+// Throws instead of writing whenever the outgoing frame is the chosen deCONZ command, to simulate
+// a transport-level failure while sending -- everything else (polling, parameter reads) passes
+// through to the inner transport untouched.
+internal class FailingCommandTransport(ISerialTransport inner, byte failingCommandId, Exception exception)
+    : ISerialTransport
+{
+    public Task OpenAsync(CancellationToken token) => inner.OpenAsync(token);
+
+    public Task CloseAsync(CancellationToken token) => inner.CloseAsync(token);
+
+    public Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token)
+    {
+        var frame = new SlipDecoder().Decode(buffer.ToArray())[0];
+        if (frame[0] == failingCommandId)
+            throw exception;
+        return inner.WriteAsync(buffer, token);
+    }
+
+    public Task<int> ReadAsync(Memory<byte> buffer, CancellationToken token) => inner.ReadAsync(buffer, token);
+
+    public void Dispose() => inner.Dispose();
+}

--- a/tests/Haus.Zigbee.Tests/Coordinator/FailingCommandTransport.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/FailingCommandTransport.cs
@@ -6,9 +6,6 @@ using Haus.Zigbee.Transport;
 
 namespace Haus.Zigbee.Tests.Coordinator;
 
-// Throws instead of writing whenever the outgoing frame is the chosen deCONZ command, to simulate
-// a transport-level failure while sending -- everything else (polling, parameter reads) passes
-// through to the inner transport untouched.
 internal class FailingCommandTransport(ISerialTransport inner, byte failingCommandId, Exception exception)
     : ISerialTransport
 {

--- a/tests/Haus.Zigbee.Tests/Coordinator/ResponderBackedTransport.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/ResponderBackedTransport.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Zigbee.Serial;
+using Haus.Zigbee.Simulator;
+using Haus.Zigbee.Transport;
+
+namespace Haus.Zigbee.Tests.Coordinator;
+
+// Adapts the simulator's DeconzResponder -- which already answers device-state polls, parameter
+// reads, and APS data-requests (auto-queuing the matching confirm) exactly like a real dongle --
+// to the ISerialTransport seam, so a coordinator-level test can drive a fully confirmed send
+// without re-implementing that protocol logic a third time.
+internal class ResponderBackedTransport(DeconzResponder responder) : ISerialTransport
+{
+    private const int ChecksumLength = 2;
+
+    private byte[] _pendingResponse = Array.Empty<byte>();
+
+    public Task OpenAsync(CancellationToken token) => Task.CompletedTask;
+
+    public Task CloseAsync(CancellationToken token) => Task.CompletedTask;
+
+    public Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token)
+    {
+        _pendingResponse = DeconzFrames.Framed(responder.HandleRequest(DecodeRequest(buffer.ToArray())));
+        return Task.CompletedTask;
+    }
+
+    public Task<int> ReadAsync(Memory<byte> buffer, CancellationToken token)
+    {
+        var response = _pendingResponse;
+        _pendingResponse = Array.Empty<byte>();
+        response.CopyTo(buffer);
+        return Task.FromResult(response.Length);
+    }
+
+    public void Dispose() { }
+
+    private static byte[] DecodeRequest(byte[] framed)
+    {
+        var frame = new SlipDecoder().Decode(framed)[0];
+        return frame[..^ChecksumLength];
+    }
+}

--- a/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorReconnectTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorReconnectTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Haus.Zigbee.Connection;
 using Haus.Zigbee.Coordinator;
+using Haus.Zigbee.Models;
 using Haus.Zigbee.Transport;
 using Xunit;
 
@@ -97,6 +98,38 @@ public class ZigbeeCoordinatorReconnectTests
         Assert.False(coordinator.IsConnected);
     }
 
+    // The MQTT-facing diagnostics events (see Haus.Zigbee.Host's ZigbeeDiagnosticsPublisher) are
+    // this coordinator's only externally-observable signal of a fatal transport failure besides
+    // IsConnected itself, so both need to fire from the exact same HandleTransportFailure call
+    // that flips IsConnected false above -- not just once at initial connect.
+    [Fact]
+    public async Task WhenTheTransportThrowsIOExceptionDuringPollingThenTransportErrorAndDisconnectedStatusFire()
+    {
+        var dongle = NewConfiguredDongle();
+        var unpluggedTransport = new ThrowOnceOnReadTransport(dongle, throwOnReadCall: 4);
+        using var coordinator = new ZigbeeCoordinator(
+            () => unpluggedTransport,
+            channelRoundTripTimeout: ShortRoundTripTimeout
+        );
+        var reportedError = new TaskCompletionSource<ZigbeeTransportError>();
+        coordinator.TransportError += (_, error) => reportedError.TrySetResult(error);
+        var disconnectedStatus = new TaskCompletionSource<ZigbeeConnectionStatus>();
+        coordinator.ConnectionStatusChanged += (_, status) =>
+        {
+            if (!status.IsConnected)
+                disconnectedStatus.TrySetResult(status);
+        };
+
+        await coordinator.ConnectAsync(CancellationToken.None);
+
+        var error = await WaitFor(reportedError.Task);
+        var status = await WaitFor(disconnectedStatus.Task);
+
+        Assert.Equal(nameof(IOException), error.ErrorType);
+        Assert.False(status.IsConnected);
+        Assert.False(coordinator.IsConnected);
+    }
+
     // Before TransportComponents, ZigbeeCoordinator held eight separately-mutable fields
     // (_transport, _channel, _sender, ...) that a rebuild reassigned one at a time with no
     // synchronization: a concurrent caller could read a mismatched mix of old and new
@@ -183,6 +216,13 @@ public class ZigbeeCoordinatorReconnectTests
         while (!condition() && !timeout.IsCancellationRequested)
             await Task.Delay(10);
         Assert.True(condition(), "condition was not met within the timeout");
+    }
+
+    private static async Task<T> WaitFor<T>(Task<T> task)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(task, completed);
+        return await task;
     }
 
     // Wraps a working transport and makes exactly one chosen ReadAsync call hang forever instead

--- a/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
@@ -264,23 +264,6 @@ public class ZigbeeCoordinatorTests
         );
     }
 
-    [Fact]
-    public async Task WhenAPollIterationThrowsThenTheTransportErrorEventReportsTheFailure()
-    {
-        SetNetworkParameters();
-        var transport = new FailOnceOnReadTransport(_dongle, failOnReadCall: 4);
-        using var coordinator = new ZigbeeCoordinator(transport);
-        var reported = new TaskCompletionSource<ZigbeeTransportError>();
-        coordinator.TransportError += (_, error) => reported.TrySetResult(error);
-
-        await coordinator.ConnectAsync(CancellationToken.None);
-
-        var error = await WaitFor(reported.Task);
-        Assert.Equal(nameof(IOException), error.ErrorType);
-        Assert.Null(error.NetworkAddress);
-        Assert.Null(error.IeeeAddress);
-    }
-
     private async Task WaitUntilPolledAtLeast(int count)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
@@ -7,9 +7,9 @@ using Haus.Zigbee.Coordinator;
 using Haus.Zigbee.Models;
 using Haus.Zigbee.Serial.Frames;
 using Haus.Zigbee.Simulator;
+using Haus.Zigbee.Tests.Support;
 using Haus.Zigbee.Transport;
 using Haus.Zigbee.Zcl;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Tests.Coordinator;
@@ -315,58 +315,6 @@ public class ZigbeeCoordinatorTests
 
         public void Dispose() => inner.Dispose();
     }
-
-    // Each CreateLogger call gets its own logger instance tagged with its own category, all
-    // writing into one shared, lock-protected list -- so entries stay attributed to whichever
-    // type actually logged them, even though several types share this one factory.
-    private class CapturingLoggerFactory : ILoggerFactory
-    {
-        private readonly List<LogEntry> _entries = new();
-
-        public IReadOnlyList<LogEntry> Entries
-        {
-            get
-            {
-                lock (_entries)
-                    return _entries.ToList();
-            }
-        }
-
-        public ILogger CreateLogger(string categoryName) => new CategoryLogger(categoryName, _entries);
-
-        public void AddProvider(ILoggerProvider provider) { }
-
-        public void Dispose() { }
-
-        private class CategoryLogger(string category, List<LogEntry> entries) : ILogger
-        {
-            public IDisposable BeginScope<TState>(TState state)
-                where TState : notnull => NullScope.Instance;
-
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(
-                LogLevel logLevel,
-                EventId eventId,
-                TState state,
-                Exception? exception,
-                Func<TState, Exception?, string> formatter
-            )
-            {
-                lock (entries)
-                    entries.Add(new LogEntry(category, logLevel, exception));
-            }
-        }
-
-        private class NullScope : IDisposable
-        {
-            public static readonly NullScope Instance = new();
-
-            public void Dispose() { }
-        }
-    }
-
-    private record LogEntry(string Category, LogLevel Level, Exception? Exception);
 
     [Fact]
     public async Task WhenADeviceAnnouncesWhileConnectedThenItIsRelayedThroughTheDeviceJoinedEvent()

--- a/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
@@ -20,6 +20,7 @@ public class ZigbeeCoordinatorTests
     private const byte PanIdParameterId = 0x05;
     private const byte ChannelParameterId = 0x1C;
     private const byte PermitJoinParameterId = 0x21;
+    private const byte ApsDataRequestCommandId = 0x12;
 
     private readonly FakeDeconzCoordinator _dongle = new();
 
@@ -39,6 +40,89 @@ public class ZigbeeCoordinatorTests
         Assert.Equal(new IeeeAddress(0x00212effff001122), config.MacAddress);
         Assert.Equal((ushort)0x1a62, config.PanId);
         Assert.Equal((byte)0x0f, config.Channel);
+    }
+
+    [Fact]
+    public async Task WhenConnectedThenTheConnectionStatusChangedEventReportsConnected()
+    {
+        SetNetworkParameters();
+        using var coordinator = new ZigbeeCoordinator(_dongle);
+        var reported = new TaskCompletionSource<ZigbeeConnectionStatus>();
+        coordinator.ConnectionStatusChanged += (_, status) => reported.TrySetResult(status);
+
+        await coordinator.ConnectAsync(CancellationToken.None);
+
+        var status = await WaitFor(reported.Task);
+        Assert.True(status.IsConnected);
+        Assert.Equal(coordinator.NetworkConfig, status.NetworkConfig);
+        Assert.Null(status.Reason);
+    }
+
+    [Fact]
+    public async Task WhenSendingACommandSucceedsThenTheCommandSentEventReportsTheDestinationAndCommand()
+    {
+        var responder = new DeconzResponder();
+        responder.SetParameter(MacAddressParameterId, new byte[] { 0x22, 0x11, 0x00, 0xff, 0xff, 0x2e, 0x21, 0x00 });
+        responder.SetParameter(PanIdParameterId, new byte[] { 0x62, 0x1a });
+        responder.SetParameter(ChannelParameterId, new byte[] { 0x0f });
+        using var coordinator = new ZigbeeCoordinator(new ResponderBackedTransport(responder));
+        await coordinator.ConnectAsync(CancellationToken.None);
+        var reported = new TaskCompletionSource<ZigbeeCommandSent>();
+        coordinator.CommandSent += (_, sent) => reported.TrySetResult(sent);
+        var request = new ZigbeeCommandRequest(
+            Destination: ApsDestination.Nwk(0x1234, 0x01),
+            SourceEndpoint: 0x01,
+            ProfileId: 0x0104,
+            ClusterId: 0x0006,
+            CommandId: 0x01,
+            Payload: new byte[] { 0xaa, 0xbb },
+            DisableDefaultResponse: true
+        );
+
+        await coordinator.SendCommandAsync(request, CancellationToken.None);
+
+        var sent = await WaitFor(reported.Task);
+        Assert.Equal(request.Destination, sent.Destination);
+        Assert.Equal(request.ClusterId, sent.ClusterId);
+        Assert.Equal(request.CommandId, sent.CommandId);
+    }
+
+    [Fact]
+    public async Task WhenSendingACommandFailsThenTheTransportErrorEventReportsTheFailure()
+    {
+        var responder = new DeconzResponder();
+        responder.SetParameter(MacAddressParameterId, new byte[] { 0x22, 0x11, 0x00, 0xff, 0xff, 0x2e, 0x21, 0x00 });
+        responder.SetParameter(PanIdParameterId, new byte[] { 0x62, 0x1a });
+        responder.SetParameter(ChannelParameterId, new byte[] { 0x0f });
+        var failure = new InvalidOperationException("write failed");
+        var transport = new FailingCommandTransport(
+            new ResponderBackedTransport(responder),
+            ApsDataRequestCommandId,
+            failure
+        );
+        using var coordinator = new ZigbeeCoordinator(transport);
+        await coordinator.ConnectAsync(CancellationToken.None);
+        var reported = new TaskCompletionSource<ZigbeeTransportError>();
+        coordinator.TransportError += (_, error) => reported.TrySetResult(error);
+        var request = new ZigbeeCommandRequest(
+            Destination: ApsDestination.Nwk(0x1234, 0x01),
+            SourceEndpoint: 0x01,
+            ProfileId: 0x0104,
+            ClusterId: 0x0006,
+            CommandId: 0x01,
+            Payload: new byte[] { 0xaa, 0xbb },
+            DisableDefaultResponse: true
+        );
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            coordinator.SendCommandAsync(request, CancellationToken.None)
+        );
+
+        var error = await WaitFor(reported.Task);
+        Assert.Equal(nameof(InvalidOperationException), error.ErrorType);
+        Assert.Equal("write failed", error.Message);
+        Assert.Equal((ushort)0x1234, error.NetworkAddress);
+        Assert.Null(error.IeeeAddress);
     }
 
     [Fact]
@@ -178,6 +262,23 @@ public class ZigbeeCoordinatorTests
             loggerFactory.Entries,
             entry => entry.Category == typeof(ZigbeeCoordinator).FullName && entry.Exception is not null
         );
+    }
+
+    [Fact]
+    public async Task WhenAPollIterationThrowsThenTheTransportErrorEventReportsTheFailure()
+    {
+        SetNetworkParameters();
+        var transport = new FailOnceOnReadTransport(_dongle, failOnReadCall: 4);
+        using var coordinator = new ZigbeeCoordinator(transport);
+        var reported = new TaskCompletionSource<ZigbeeTransportError>();
+        coordinator.TransportError += (_, error) => reported.TrySetResult(error);
+
+        await coordinator.ConnectAsync(CancellationToken.None);
+
+        var error = await WaitFor(reported.Task);
+        Assert.Equal(nameof(IOException), error.ErrorType);
+        Assert.Null(error.NetworkAddress);
+        Assert.Null(error.IeeeAddress);
     }
 
     private async Task WaitUntilPolledAtLeast(int count)

--- a/tests/Haus.Zigbee.Tests/Support/CapturingLoggerFactory.cs
+++ b/tests/Haus.Zigbee.Tests/Support/CapturingLoggerFactory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Haus.Zigbee.Tests.Support;
+
+// Each CreateLogger call gets its own logger instance tagged with its own category, all writing
+// into one shared, lock-protected list -- so entries stay attributed to whichever type actually
+// logged them, even though several types can share this one factory.
+public class CapturingLoggerFactory : ILoggerFactory
+{
+    private readonly List<LogEntry> _entries = new();
+
+    public IReadOnlyList<LogEntry> Entries
+    {
+        get
+        {
+            lock (_entries)
+                return _entries.ToList();
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName) => new CategoryLogger(categoryName, _entries);
+
+    public void AddProvider(ILoggerProvider provider) { }
+
+    public void Dispose() { }
+
+    private class CategoryLogger(string category, List<LogEntry> entries) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            lock (entries)
+                entries.Add(new LogEntry(category, logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose() { }
+    }
+}
+
+public record LogEntry(string Category, LogLevel Level, string Message, Exception? Exception);

--- a/tests/Haus.Zigbee.Tests/Transport/TcpSerialTransportTests.cs
+++ b/tests/Haus.Zigbee.Tests/Transport/TcpSerialTransportTests.cs
@@ -4,7 +4,9 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Haus.Zigbee.Tests.Support;
 using Haus.Zigbee.Transport;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Tests.Transport;
@@ -38,6 +40,47 @@ public class TcpSerialTransportTests : IAsyncLifetime
 
         using var accepted = await acceptTask;
         Assert.True(accepted.Connected);
+    }
+
+    [Fact]
+    public async Task OpenAsync_LogsTheConnectionAtInformationLevel()
+    {
+        var loggerFactory = new CapturingLoggerFactory();
+        using var transport = new TcpSerialTransport(
+            "127.0.0.1",
+            _port,
+            loggerFactory.CreateLogger<TcpSerialTransport>()
+        );
+        var acceptTask = _listener!.AcceptTcpClientAsync();
+
+        await transport.OpenAsync(CancellationToken.None);
+        using var accepted = await acceptTask;
+
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Information && entry.Message.Contains($"{_port}")
+        );
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenTheConnectionResetsWhileAReadIsPendingThenAWarningIsLogged()
+    {
+        var loggerFactory = new CapturingLoggerFactory();
+        using var transport = new TcpSerialTransport(
+            "127.0.0.1",
+            _port,
+            loggerFactory.CreateLogger<TcpSerialTransport>()
+        );
+        var acceptTask = _listener!.AcceptTcpClientAsync();
+        await transport.OpenAsync(CancellationToken.None);
+        using var accepted = await acceptTask;
+
+        var readTask = transport.ReadAsync(new byte[4], CancellationToken.None);
+        accepted.Client.LingerState = new LingerOption(true, 0);
+        accepted.Client.Close();
+        await Assert.ThrowsAsync<IOException>(() => readTask);
+
+        Assert.Contains(loggerFactory.Entries, entry => entry.Level == LogLevel.Warning);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Part 1/3 of #48. Haus.Zigbee.Host previously had zero external visibility into Zigbee network/device state or raw traffic. This PR publishes that visibility onto a new MQTT topic so a follow-up task in Haus.Web.Host can expose it via HTTP/SignalR. **No HTTP surface is added to Haus.Zigbee.Host itself** — that was explicitly rejected in favor of this MQTT-based approach.

## Wire contract for the follow-up consumer

**Topic:** `haus/zigbee` (`DefaultHausMqttTopics.ZigbeeTopic`, `Haus.Core.Models/Common/DefaultHausMqttTopics.cs`)

**Envelope:** identical shape to the existing `haus/events` messages — `HausEvent<T>` (`{ "type": "<known-type>", "payload": { ... }, "timestamp": "..." }`), produced via `IHausEventCreator<T>.AsHausEvent()`. Six payload types live in `Haus.Core.Models/Zigbee/Events/`:

| `Type` string | Record | Payload |
|---|---|---|
| `zigbee_connection_status_changed` | `ZigbeeConnectionStatusChangedEvent` | `IsConnected`, `NetworkConfig?` (`ZigbeeNetworkConfigModel`: MacAddress/PanId/Channel, null when disconnected), `Reason?` (present only on disconnect) |
| `zigbee_device_joined` | `ZigbeeDeviceJoinedEvent` | `IeeeAddress`, `NetworkAddress` |
| `zigbee_device_info_discovered` | `ZigbeeDeviceInfoDiscoveredEvent` | `IeeeAddress`, `ManufacturerName`, `ModelIdentifier`, `Endpoints` (`ZigbeeEndpointModel[]`: EndpointId + InClusters/OutClusters) |
| `zigbee_attribute_report_received` | `ZigbeeAttributeReportReceivedEvent` | `NetworkAddress`, `IeeeAddress?` (resolved when known), `ClusterId`, `AttributeId`, `DataType`, `RawValue`, `StringValue?` |
| `zigbee_command_sent` | `ZigbeeCommandSentEvent` | `NetworkAddress?`, `IeeeAddress?` (exactly one populated, depending on how the command's destination was addressed), `ClusterId`, `CommandId` |
| `zigbee_transport_error` | `ZigbeeTransportErrorEvent` | `ErrorType`, `Message`, `NetworkAddress?`, `IeeeAddress?` (best-effort, resolved via the address registry when a network address is known) |

`zigbee_transport_error` is the highest-value addition: it's what would have surfaced this week's production incident, where a dead deCONZ connection went undetected for 40+ hours because nothing observable reflected it. It fires both on poll-loop failures (`ZigbeeCoordinator.PollSafelyAsync`) and on send failures (`ZigbeeCoordinator.SendCommandAsync`), and `zigbee_connection_status_changed` now fires on both connect *and* disconnect for the same reason.

## What changed

1. **`IZigbeeCoordinator`** gained three new events: `ConnectionStatusChanged`, `CommandSent`, `TransportError`, alongside the existing `DeviceJoined`/`AttributeReported`. `ZigbeeCoordinator` raises them from `ConnectAsync`, `SendCommandAsync`, and the poll loop's existing catch site.
2. **`ZigbeeDiagnosticsPublisher`** (new, `Haus.Zigbee.Host/Zigbee/Services/`) — sits alongside `ZigbeeInboundRelay`/`ZigbeeOutboundRelay`/`ZigbeeHostHealthPublisher`, subscribes to all five coordinator events plus `AttributeReported`/`DeviceJoined`, maps each to its envelope type, and publishes via the existing `IHausMqttClient` abstraction. Wired into `ZigbeeHausBridge` alongside the existing inbound relay, each in its own try/catch so a diagnostics-publish failure never blocks the domain-event path.
3. **Real-broker integration test** (`ZigbeeDiagnosticsPublisherRealBrokerTests`) exercises the publisher against an actual MQTT broker (not `FakeMqttClientFactory`), mirroring `Haus.Web.Host.Tests`'s established pattern. `ConfigurationFactory` now layers environment variables so it picks up `Haus__Server` the same way `Mqtt__Server` is picked up elsewhere; the Makefile's `test-unit` target now exports both against the same disposable CI broker.
4. **Structured logging** added to the previously-silent raw transport layer (`FrameReader`, `DeconzChannel`, `ApsPollLoop`, `ApsSender`, `SerialPortTransport`, `TcpSerialTransport`): Debug for routine sent/received frame traffic, Warning for a discarded invalid-checksum frame / timed-out confirm / connection failure, Information for transport open/close — correlated by sequence number or network address. `ZigbeeCoordinator` and `ServiceCollectionExtensions.CreateTransport` now thread `ILoggerFactory` down to every logging component, following the same optional-logger convention `DeviceInterview` already used.

## Test plan

- [x] `dotnet build` — clean across the whole solution (the only failure is `Haus.Acceptance.Tests`' Playwright browser install, a pre-existing sandbox limitation unrelated to this change)
- [x] `Haus.Zigbee.Tests` — 225/225 passing (was 218; +7 new: logging behavior across the transport layer, plus the new coordinator events)
- [x] `Haus.Zigbee.Host.Tests` — 80/80 passing (was 65; +15 new: `ZigbeeDiagnosticsPublisher` unit tests, real-broker test, `ZigbeeHausBridge` wiring tests), including 8 consecutive full-suite runs against a real disposable broker to rule out flakiness from a race between `SubscribeAsync` and `PublishAsync` on MQTTnet's managed client (fixed by retrying the publish inside the test's own `Eventually.AssertAsync` loop rather than relying on a single publish landing before the subscription is confirmed against the broker)
- [x] `Haus.Zigbee.Simulator.Tests` — 21/21 passing (unchanged)
- [x] `Haus.Core.Models.Tests` — 9/9 passing (unchanged)
- [x] `Haus.Core.Tests` — 228/228 passing (unchanged)
- [x] `Haus.Site.Host.Tests` — 120/120 passing (unchanged)
- [x] `Haus.Mqtt.Client.Tests`, `Haus.Cqrs.Tests`, `Haus.Utilities.Tests` — all passing (unchanged)
- Did **not** touch `Haus.Web.Host` or `Haus.Site.Host` (separate follow-up tasks); `Haus.Web.Host.Tests` has 3 pre-existing failures in this sandbox from a missing `GITHUB_TOKEN` env var, unrelated to this change

Co-authored-by: omnigent <noreply@omnigent.ai>