### PR TITLE
feat(zigbee): expose zigbee diagnostics via REST and SignalR

### DIFF
--- a/src/Haus.Api.Client/HausApiClient.cs
+++ b/src/Haus.Api.Client/HausApiClient.cs
@@ -10,6 +10,7 @@ using Haus.Api.Client.Discovery;
 using Haus.Api.Client.Logs;
 using Haus.Api.Client.Options;
 using Haus.Api.Client.Rooms;
+using Haus.Api.Client.Zigbee;
 using Haus.Core.Models.Application;
 using Haus.Core.Models.ClientSettings;
 using Haus.Core.Models.Common;
@@ -20,6 +21,7 @@ using Haus.Core.Models.Discovery;
 using Haus.Core.Models.Lighting;
 using Haus.Core.Models.Logs;
 using Haus.Core.Models.Rooms;
+using Haus.Core.Models.Zigbee;
 using Microsoft.Extensions.Options;
 
 namespace Haus.Api.Client;
@@ -32,7 +34,8 @@ public interface IHausApiClient
         IDiscoveryApiClient,
         ILogsApiClient,
         IClientSettingsApiClient,
-        IApplicationApiClient { }
+        IApplicationApiClient,
+        IZigbeeApiClient { }
 
 public class HausApiClient(
     IHausApiClientFactory factory,
@@ -48,6 +51,7 @@ public class HausApiClient(
     private ILogsApiClient LogsApiClient => factory.CreateLogsClient();
     private IClientSettingsApiClient ClientSettingsApiClient => factory.CreateClientSettingsClient();
     private IApplicationApiClient ApplicationApiClient => factory.CreateApplicationClient();
+    private IZigbeeApiClient ZigbeeApiClient => factory.CreateZigbeeClient();
 
     public Task<DiscoveryModel?> GetDiscoveryStateAsync()
     {
@@ -212,5 +216,20 @@ public class HausApiClient(
     public Task<HttpResponseMessage> DownloadLatestPackageAsync(int packageId)
     {
         return ApplicationApiClient.DownloadLatestPackageAsync(packageId);
+    }
+
+    public Task<ZigbeeConnectionStatusModel?> GetZigbeeStatusAsync()
+    {
+        return ZigbeeApiClient.GetZigbeeStatusAsync();
+    }
+
+    public Task<ListResult<ZigbeeActivityEntryModel>> GetZigbeeActivityAsync()
+    {
+        return ZigbeeApiClient.GetZigbeeActivityAsync();
+    }
+
+    public Task<ListResult<ZigbeeKnownDeviceModel>> GetZigbeeDevicesAsync()
+    {
+        return ZigbeeApiClient.GetZigbeeDevicesAsync();
     }
 }

--- a/src/Haus.Api.Client/HausApiClientFactory.cs
+++ b/src/Haus.Api.Client/HausApiClientFactory.cs
@@ -8,6 +8,7 @@ using Haus.Api.Client.Discovery;
 using Haus.Api.Client.Logs;
 using Haus.Api.Client.Options;
 using Haus.Api.Client.Rooms;
+using Haus.Api.Client.Zigbee;
 using Microsoft.Extensions.Options;
 
 namespace Haus.Api.Client;
@@ -23,6 +24,7 @@ public interface IHausApiClientFactory
     ILogsApiClient CreateLogsClient();
     IClientSettingsApiClient CreateClientSettingsClient();
     IApplicationApiClient CreateApplicationClient();
+    IZigbeeApiClient CreateZigbeeClient();
 }
 
 public class HausApiClientFactory(IHttpClientFactory httpClientFactory, IOptions<HausApiClientSettings> options)
@@ -71,6 +73,11 @@ public class HausApiClientFactory(IHttpClientFactory httpClientFactory, IOptions
     public IApplicationApiClient CreateApplicationClient()
     {
         return new ApplicationApiClient(CreateClient(), options);
+    }
+
+    public IZigbeeApiClient CreateZigbeeClient()
+    {
+        return new ZigbeeApiClient(CreateClient(), options);
     }
 
     private HttpClient CreateClient()

--- a/src/Haus.Api.Client/Zigbee/ZigbeeApiClient.cs
+++ b/src/Haus.Api.Client/Zigbee/ZigbeeApiClient.cs
@@ -1,0 +1,38 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Haus.Api.Client.Common;
+using Haus.Api.Client.Options;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Microsoft.Extensions.Options;
+
+namespace Haus.Api.Client.Zigbee;
+
+public interface IZigbeeApiClient : IApiClient
+{
+    Task<ZigbeeConnectionStatusModel?> GetZigbeeStatusAsync();
+    Task<ListResult<ZigbeeActivityEntryModel>> GetZigbeeActivityAsync();
+    Task<ListResult<ZigbeeKnownDeviceModel>> GetZigbeeDevicesAsync();
+}
+
+public class ZigbeeApiClient(HttpClient httpClient, IOptions<HausApiClientSettings> options)
+    : ApiClient(httpClient, options),
+        IZigbeeApiClient
+{
+    public Task<ZigbeeConnectionStatusModel?> GetZigbeeStatusAsync()
+    {
+        return GetAsJsonAsync<ZigbeeConnectionStatusModel>("zigbee/status");
+    }
+
+    public async Task<ListResult<ZigbeeActivityEntryModel>> GetZigbeeActivityAsync()
+    {
+        return await GetAsJsonAsync<ListResult<ZigbeeActivityEntryModel>>("zigbee/activity")
+            ?? new ListResult<ZigbeeActivityEntryModel>();
+    }
+
+    public async Task<ListResult<ZigbeeKnownDeviceModel>> GetZigbeeDevicesAsync()
+    {
+        return await GetAsJsonAsync<ListResult<ZigbeeKnownDeviceModel>>("zigbee/devices")
+            ?? new ListResult<ZigbeeKnownDeviceModel>();
+    }
+}

--- a/src/Haus.Core.Models/Zigbee/ZigbeeActivityEntryModel.cs
+++ b/src/Haus.Core.Models/Zigbee/ZigbeeActivityEntryModel.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace Haus.Core.Models.Zigbee;
+
+public record ZigbeeActivityEntryModel(string EventType, DateTimeOffset OccurredAt, object Payload);

--- a/src/Haus.Core.Models/Zigbee/ZigbeeConnectionStatusModel.cs
+++ b/src/Haus.Core.Models/Zigbee/ZigbeeConnectionStatusModel.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Haus.Core.Models.Zigbee;
+
+public record ZigbeeConnectionStatusModel(bool IsConnected, string? Reason, DateTimeOffset? ChangedAt)
+{
+    public static readonly ZigbeeConnectionStatusModel Unknown = new(false, null, null);
+}

--- a/src/Haus.Core.Models/Zigbee/ZigbeeKnownDeviceModel.cs
+++ b/src/Haus.Core.Models/Zigbee/ZigbeeKnownDeviceModel.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Haus.Core.Models.Zigbee;
+
+public record ZigbeeKnownDeviceModel(
+    string IeeeAddress,
+    ushort? NetworkAddress,
+    string? ManufacturerName,
+    string? ModelIdentifier,
+    IReadOnlyList<ZigbeeEndpointModel> Endpoints,
+    DateTimeOffset LastSeenAt
+);

--- a/src/Haus.Core/Common/Events/RoutableEventFactory.cs
+++ b/src/Haus.Core/Common/Events/RoutableEventFactory.cs
@@ -4,6 +4,7 @@ using Haus.Core.Models.Devices.Events;
 using Haus.Core.Models.Devices.Sensors;
 using Haus.Core.Models.Devices.Sensors.Motion;
 using Haus.Core.Models.ExternalMessages;
+using Haus.Core.Models.Zigbee.Events;
 
 namespace Haus.Core.Common.Events;
 
@@ -24,6 +25,12 @@ public class RoutableEventFactory : IRoutableEventFactory
             DeviceDiscoveredEvent.Type => CreateRoutableEvent<DeviceDiscoveredEvent>(bytes),
             MultiSensorChanged.Type => CreateRoutableEvent<MultiSensorChanged>(bytes),
             OccupancyChangedModel.Type => CreateRoutableEvent<OccupancyChangedModel>(bytes),
+            ZigbeeConnectionStatusChangedEvent.Type => CreateRoutableEvent<ZigbeeConnectionStatusChangedEvent>(bytes),
+            ZigbeeDeviceJoinedEvent.Type => CreateRoutableEvent<ZigbeeDeviceJoinedEvent>(bytes),
+            ZigbeeDeviceInfoDiscoveredEvent.Type => CreateRoutableEvent<ZigbeeDeviceInfoDiscoveredEvent>(bytes),
+            ZigbeeAttributeReportReceivedEvent.Type => CreateRoutableEvent<ZigbeeAttributeReportReceivedEvent>(bytes),
+            ZigbeeCommandSentEvent.Type => CreateRoutableEvent<ZigbeeCommandSentEvent>(bytes),
+            ZigbeeTransportErrorEvent.Type => CreateRoutableEvent<ZigbeeTransportErrorEvent>(bytes),
             _ => null,
         };
     }

--- a/src/Haus.Core/ServiceCollectionExtensions.cs
+++ b/src/Haus.Core/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Haus.Core.Diagnostics.Factories;
 using Haus.Core.Logs;
 using Haus.Core.Logs.Factories;
 using Haus.Core.Rooms.Repositories;
+using Haus.Core.Zigbee.State;
 using Haus.Cqrs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,6 +34,8 @@ public static class ServiceCollectionExtensions
             .AddHausCqrs(coreAssembly)
             .AddTransient(p => p.GetRequiredService<IDeviceSimulatorStore>().Current)
             .AddSingleton<IDeviceSimulatorStore, DeviceSimulatorStore>()
+            .AddTransient(p => p.GetRequiredService<IZigbeeStore>().Current)
+            .AddSingleton<IZigbeeStore, ZigbeeStore>()
             .AddTransient<IRoutableEventFactory, RoutableEventFactory>()
             .AddTransient<ILogEntryModelFactory, LogEntryModelFactory>()
             .AddTransient<IMqttDiagnosticsMessageFactory, MqttDiagnosticsMessageFactory>();

--- a/src/Haus.Core/Zigbee/Events/ZigbeeAttributeReportReceivedEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeAttributeReportReceivedEventHandler.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeAttributeReportReceivedEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeAttributeReportReceivedEvent>>
+{
+    public Task Handle(
+        RoutableEvent<ZigbeeAttributeReportReceivedEvent> notification,
+        CancellationToken cancellationToken
+    )
+    {
+        store.PublishNext(s =>
+            s.RecordActivity(new ZigbeeActivityEntryModel(notification.Type, clock.UtcNowOffset, notification.Payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Core/Zigbee/Events/ZigbeeCommandSentEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeCommandSentEventHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeCommandSentEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeCommandSentEvent>>
+{
+    public Task Handle(RoutableEvent<ZigbeeCommandSentEvent> notification, CancellationToken cancellationToken)
+    {
+        store.PublishNext(s =>
+            s.RecordActivity(new ZigbeeActivityEntryModel(notification.Type, clock.UtcNowOffset, notification.Payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Core/Zigbee/Events/ZigbeeConnectionStatusChangedEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeConnectionStatusChangedEventHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeConnectionStatusChangedEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeConnectionStatusChangedEvent>>
+{
+    public Task Handle(
+        RoutableEvent<ZigbeeConnectionStatusChangedEvent> notification,
+        CancellationToken cancellationToken
+    )
+    {
+        var payload = notification.Payload;
+        var status = new ZigbeeConnectionStatusModel(payload.IsConnected, payload.Reason, clock.UtcNowOffset);
+
+        store.PublishNext(s =>
+            s.UpdateConnectionStatus(status)
+                .RecordActivity(new ZigbeeActivityEntryModel(notification.Type, clock.UtcNowOffset, payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Core/Zigbee/Events/ZigbeeDeviceInfoDiscoveredEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeDeviceInfoDiscoveredEventHandler.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeDeviceInfoDiscoveredEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeDeviceInfoDiscoveredEvent>>
+{
+    public Task Handle(RoutableEvent<ZigbeeDeviceInfoDiscoveredEvent> notification, CancellationToken cancellationToken)
+    {
+        var payload = notification.Payload;
+        var seenAt = clock.UtcNowOffset;
+
+        store.PublishNext(s =>
+            s.RecordDeviceInfoDiscovered(
+                    payload.IeeeAddress,
+                    payload.ManufacturerName,
+                    payload.ModelIdentifier,
+                    payload.Endpoints,
+                    seenAt
+                )
+                .RecordActivity(new ZigbeeActivityEntryModel(notification.Type, seenAt, payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Core/Zigbee/Events/ZigbeeDeviceJoinedEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeDeviceJoinedEventHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeDeviceJoinedEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeDeviceJoinedEvent>>
+{
+    public Task Handle(RoutableEvent<ZigbeeDeviceJoinedEvent> notification, CancellationToken cancellationToken)
+    {
+        var payload = notification.Payload;
+        var seenAt = clock.UtcNowOffset;
+
+        store.PublishNext(s =>
+            s.RecordDeviceJoined(payload.IeeeAddress, payload.NetworkAddress, seenAt)
+                .RecordActivity(new ZigbeeActivityEntryModel(notification.Type, seenAt, payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Core/Zigbee/Events/ZigbeeTransportErrorEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeTransportErrorEventHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeTransportErrorEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeTransportErrorEvent>>
+{
+    public Task Handle(RoutableEvent<ZigbeeTransportErrorEvent> notification, CancellationToken cancellationToken)
+    {
+        store.PublishNext(s =>
+            s.RecordActivity(new ZigbeeActivityEntryModel(notification.Type, clock.UtcNowOffset, notification.Payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Core/Zigbee/Queries/GetKnownZigbeeDevicesQuery.cs
+++ b/src/Haus.Core/Zigbee/Queries/GetKnownZigbeeDevicesQuery.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Queries;
+
+namespace Haus.Core.Zigbee.Queries;
+
+public record GetKnownZigbeeDevicesQuery : IQuery<ListResult<ZigbeeKnownDeviceModel>>;
+
+public class GetKnownZigbeeDevicesQueryHandler(IZigbeeState state)
+    : IQueryHandler<GetKnownZigbeeDevicesQuery, ListResult<ZigbeeKnownDeviceModel>>
+{
+    public Task<ListResult<ZigbeeKnownDeviceModel>> Handle(
+        GetKnownZigbeeDevicesQuery request,
+        CancellationToken cancellationToken
+    )
+    {
+        return Task.FromResult(new ListResult<ZigbeeKnownDeviceModel>(state.KnownDevices.Values.ToArray()));
+    }
+}

--- a/src/Haus.Core/Zigbee/Queries/GetRecentZigbeeActivityQuery.cs
+++ b/src/Haus.Core/Zigbee/Queries/GetRecentZigbeeActivityQuery.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Queries;
+
+namespace Haus.Core.Zigbee.Queries;
+
+public record GetRecentZigbeeActivityQuery : IQuery<ListResult<ZigbeeActivityEntryModel>>;
+
+public class GetRecentZigbeeActivityQueryHandler(IZigbeeState state)
+    : IQueryHandler<GetRecentZigbeeActivityQuery, ListResult<ZigbeeActivityEntryModel>>
+{
+    public Task<ListResult<ZigbeeActivityEntryModel>> Handle(
+        GetRecentZigbeeActivityQuery request,
+        CancellationToken cancellationToken
+    )
+    {
+        var mostRecentFirst = state.RecentActivity.Reverse().ToArray();
+        return Task.FromResult(new ListResult<ZigbeeActivityEntryModel>(mostRecentFirst));
+    }
+}

--- a/src/Haus.Core/Zigbee/Queries/GetZigbeeConnectionStatusQuery.cs
+++ b/src/Haus.Core/Zigbee/Queries/GetZigbeeConnectionStatusQuery.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Queries;
+
+namespace Haus.Core.Zigbee.Queries;
+
+public record GetZigbeeConnectionStatusQuery : IQuery<ZigbeeConnectionStatusModel>;
+
+public class GetZigbeeConnectionStatusQueryHandler(IZigbeeState state)
+    : IQueryHandler<GetZigbeeConnectionStatusQuery, ZigbeeConnectionStatusModel>
+{
+    public Task<ZigbeeConnectionStatusModel> Handle(
+        GetZigbeeConnectionStatusQuery request,
+        CancellationToken cancellationToken
+    )
+    {
+        return Task.FromResult(state.ConnectionStatus);
+    }
+}

--- a/src/Haus.Core/Zigbee/State/ZigbeeState.cs
+++ b/src/Haus.Core/Zigbee/State/ZigbeeState.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Haus.Core.Models.Zigbee;
+
+namespace Haus.Core.Zigbee.State;
+
+public interface IZigbeeState
+{
+    ZigbeeConnectionStatusModel ConnectionStatus { get; }
+    ImmutableArray<ZigbeeActivityEntryModel> RecentActivity { get; }
+    ImmutableDictionary<string, ZigbeeKnownDeviceModel> KnownDevices { get; }
+    IZigbeeState UpdateConnectionStatus(ZigbeeConnectionStatusModel status);
+    IZigbeeState RecordActivity(ZigbeeActivityEntryModel entry);
+    IZigbeeState RecordDeviceJoined(string ieeeAddress, ushort networkAddress, DateTimeOffset seenAt);
+    IZigbeeState RecordDeviceInfoDiscovered(
+        string ieeeAddress,
+        string manufacturerName,
+        string modelIdentifier,
+        IReadOnlyList<ZigbeeEndpointModel> endpoints,
+        DateTimeOffset seenAt
+    );
+}
+
+public record ZigbeeState(
+    ZigbeeConnectionStatusModel ConnectionStatus,
+    ImmutableArray<ZigbeeActivityEntryModel> RecentActivity,
+    ImmutableDictionary<string, ZigbeeKnownDeviceModel> KnownDevices
+) : IZigbeeState
+{
+    public const int MaxRecentActivity = 100;
+
+    public static readonly ZigbeeState Initial = new(
+        ZigbeeConnectionStatusModel.Unknown,
+        ImmutableArray<ZigbeeActivityEntryModel>.Empty,
+        ImmutableDictionary<string, ZigbeeKnownDeviceModel>.Empty
+    );
+
+    public IZigbeeState UpdateConnectionStatus(ZigbeeConnectionStatusModel status)
+    {
+        return this with { ConnectionStatus = status };
+    }
+
+    public IZigbeeState RecordActivity(ZigbeeActivityEntryModel entry)
+    {
+        var updated = RecentActivity.Add(entry);
+        if (updated.Length > MaxRecentActivity)
+            updated = updated.RemoveAt(0);
+
+        return this with
+        {
+            RecentActivity = updated,
+        };
+    }
+
+    public IZigbeeState RecordDeviceJoined(string ieeeAddress, ushort networkAddress, DateTimeOffset seenAt)
+    {
+        var existing = KnownDevices.GetValueOrDefault(ieeeAddress);
+        var device = existing is null
+            ? new ZigbeeKnownDeviceModel(ieeeAddress, networkAddress, null, null, [], seenAt)
+            : existing with
+            {
+                NetworkAddress = networkAddress,
+                LastSeenAt = seenAt,
+            };
+
+        return this with
+        {
+            KnownDevices = KnownDevices.SetItem(ieeeAddress, device),
+        };
+    }
+
+    public IZigbeeState RecordDeviceInfoDiscovered(
+        string ieeeAddress,
+        string manufacturerName,
+        string modelIdentifier,
+        IReadOnlyList<ZigbeeEndpointModel> endpoints,
+        DateTimeOffset seenAt
+    )
+    {
+        var existing = KnownDevices.GetValueOrDefault(ieeeAddress);
+        var device = existing is null
+            ? new ZigbeeKnownDeviceModel(ieeeAddress, null, manufacturerName, modelIdentifier, endpoints, seenAt)
+            : existing with
+            {
+                ManufacturerName = manufacturerName,
+                ModelIdentifier = modelIdentifier,
+                Endpoints = endpoints,
+                LastSeenAt = seenAt,
+            };
+
+        return this with
+        {
+            KnownDevices = KnownDevices.SetItem(ieeeAddress, device),
+        };
+    }
+}

--- a/src/Haus.Core/Zigbee/State/ZigbeeStore.cs
+++ b/src/Haus.Core/Zigbee/State/ZigbeeStore.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reactive.Subjects;
+
+namespace Haus.Core.Zigbee.State;
+
+public interface IZigbeeStore : IObservable<IZigbeeState>
+{
+    IZigbeeState Current { get; }
+    void Publish(IZigbeeState state);
+    void PublishNext(Func<IZigbeeState, IZigbeeState> generateNextState);
+}
+
+public class ZigbeeStore : IZigbeeStore
+{
+    private readonly BehaviorSubject<IZigbeeState> _subject = new(ZigbeeState.Initial);
+
+    public IZigbeeState Current => _subject.Value;
+
+    public void Publish(IZigbeeState state)
+    {
+        _subject.OnNext(state);
+    }
+
+    public void PublishNext(Func<IZigbeeState, IZigbeeState> generateNextState)
+    {
+        var next = generateNextState(Current);
+        if (ReferenceEquals(next, Current))
+            return;
+
+        Publish(next);
+    }
+
+    public IDisposable Subscribe(IObserver<IZigbeeState> observer)
+    {
+        return _subject.Subscribe(observer);
+    }
+}

--- a/src/Haus.Web.Host/Zigbee/ZigbeeController.cs
+++ b/src/Haus.Web.Host/Zigbee/ZigbeeController.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.Queries;
+using Haus.Cqrs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Haus.Web.Host.Zigbee;
+
+[Authorize]
+[ApiController]
+[Route("api/zigbee")]
+public class ZigbeeController(IHausBus hausBus) : Controller
+{
+    [HttpGet("status")]
+    public async Task<ZigbeeConnectionStatusModel> GetStatus()
+    {
+        return await hausBus.ExecuteQueryAsync(new GetZigbeeConnectionStatusQuery());
+    }
+
+    [HttpGet("activity")]
+    public async Task<ListResult<ZigbeeActivityEntryModel>> GetActivity()
+    {
+        return await hausBus.ExecuteQueryAsync(new GetRecentZigbeeActivityQuery());
+    }
+
+    [HttpGet("devices")]
+    public async Task<ListResult<ZigbeeKnownDeviceModel>> GetDevices()
+    {
+        return await hausBus.ExecuteQueryAsync(new GetKnownZigbeeDevicesQuery());
+    }
+}

--- a/tests/Haus.Core.Tests/Common/Events/RoutableEventFactoryTests.cs
+++ b/tests/Haus.Core.Tests/Common/Events/RoutableEventFactoryTests.cs
@@ -4,6 +4,7 @@ using Haus.Core.Models;
 using Haus.Core.Models.Devices.Events;
 using Haus.Core.Models.Devices.Sensors;
 using Haus.Core.Models.Devices.Sensors.Motion;
+using Haus.Core.Models.Zigbee.Events;
 using Xunit;
 
 namespace Haus.Core.Tests.Common.Events;
@@ -40,6 +41,74 @@ public class RoutableHausEventFactoryTest
         var routableEvent = _factory.Create(bytes);
 
         Assert.IsType<RoutableEvent<OccupancyChangedModel>>(routableEvent);
+    }
+
+    [Fact]
+    public void WhenZigbeeConnectionStatusChangedThenReturnsRoutableEventFromZigbeeConnectionStatusChanged()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(
+            new ZigbeeConnectionStatusChangedEvent(true, null, null).AsHausEvent()
+        );
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeConnectionStatusChangedEvent>>(routableEvent);
+    }
+
+    [Fact]
+    public void WhenZigbeeDeviceJoinedThenReturnsRoutableEventFromZigbeeDeviceJoined()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(new ZigbeeDeviceJoinedEvent("ieee-1", 1).AsHausEvent());
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeDeviceJoinedEvent>>(routableEvent);
+    }
+
+    [Fact]
+    public void WhenZigbeeDeviceInfoDiscoveredThenReturnsRoutableEventFromZigbeeDeviceInfoDiscovered()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(
+            new ZigbeeDeviceInfoDiscoveredEvent("ieee-1", "Acme", "Widget", []).AsHausEvent()
+        );
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeDeviceInfoDiscoveredEvent>>(routableEvent);
+    }
+
+    [Fact]
+    public void WhenZigbeeAttributeReportReceivedThenReturnsRoutableEventFromZigbeeAttributeReportReceived()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(
+            new ZigbeeAttributeReportReceivedEvent(1, "ieee-1", 1, 1, 0, 0, null).AsHausEvent()
+        );
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeAttributeReportReceivedEvent>>(routableEvent);
+    }
+
+    [Fact]
+    public void WhenZigbeeCommandSentThenReturnsRoutableEventFromZigbeeCommandSent()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(new ZigbeeCommandSentEvent(1, "ieee-1", 1, 1).AsHausEvent());
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeCommandSentEvent>>(routableEvent);
+    }
+
+    [Fact]
+    public void WhenZigbeeTransportErrorThenReturnsRoutableEventFromZigbeeTransportError()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(
+            new ZigbeeTransportErrorEvent("timeout", "boom", 1, "ieee-1").AsHausEvent()
+        );
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeTransportErrorEvent>>(routableEvent);
     }
 
     [Fact]

--- a/tests/Haus.Core.Tests/Zigbee/Events/ZigbeeEventHandlersTests.cs
+++ b/tests/Haus.Core.Tests/Zigbee/Events/ZigbeeEventHandlersTests.cs
@@ -1,0 +1,101 @@
+using System.Threading.Tasks;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs;
+using Haus.Testing.Support;
+using Xunit;
+
+namespace Haus.Core.Tests.Zigbee.Events;
+
+public class ZigbeeEventHandlersTests
+{
+    private readonly IHausBus _hausBus;
+    private readonly IZigbeeStore _store;
+
+    public ZigbeeEventHandlersTests()
+    {
+        _store = new ZigbeeStore();
+        _hausBus = HausBusFactory.Create(configureServices: services => services.Replace<IZigbeeStore>(_store));
+    }
+
+    [Fact]
+    public async Task WhenConnectionStatusChangedEventReceivedThenStateHasNewConnectionStatus()
+    {
+        await _hausBus.PublishAsync(
+            RoutableEvent.FromEvent(new ZigbeeConnectionStatusChangedEvent(true, null, "connected"))
+        );
+
+        Assert.True(_store.Current.ConnectionStatus.IsConnected);
+        Assert.Equal("connected", _store.Current.ConnectionStatus.Reason);
+    }
+
+    [Fact]
+    public async Task WhenConnectionStatusChangedEventReceivedThenActivityIsRecorded()
+    {
+        await _hausBus.PublishAsync(
+            RoutableEvent.FromEvent(new ZigbeeConnectionStatusChangedEvent(true, null, "connected"))
+        );
+
+        Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeConnectionStatusChangedEvent.Type);
+    }
+
+    [Fact]
+    public async Task WhenDeviceJoinedEventReceivedThenStateHasKnownDevice()
+    {
+        await _hausBus.PublishAsync(RoutableEvent.FromEvent(new ZigbeeDeviceJoinedEvent("ieee-1", 42)));
+
+        var device = Assert.Single(_store.Current.KnownDevices.Values);
+        Assert.Equal("ieee-1", device.IeeeAddress);
+        Assert.Equal((ushort)42, device.NetworkAddress);
+    }
+
+    [Fact]
+    public async Task WhenDeviceJoinedEventReceivedThenActivityIsRecorded()
+    {
+        await _hausBus.PublishAsync(RoutableEvent.FromEvent(new ZigbeeDeviceJoinedEvent("ieee-1", 42)));
+
+        Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeDeviceJoinedEvent.Type);
+    }
+
+    [Fact]
+    public async Task WhenDeviceInfoDiscoveredEventReceivedThenStateHasKnownDeviceInfo()
+    {
+        await _hausBus.PublishAsync(
+            RoutableEvent.FromEvent(new ZigbeeDeviceInfoDiscoveredEvent("ieee-1", "Acme", "Widget", []))
+        );
+
+        var device = Assert.Single(_store.Current.KnownDevices.Values);
+        Assert.Equal("Acme", device.ManufacturerName);
+        Assert.Equal("Widget", device.ModelIdentifier);
+    }
+
+    [Fact]
+    public async Task WhenAttributeReportReceivedEventReceivedThenActivityIsRecorded()
+    {
+        await _hausBus.PublishAsync(
+            RoutableEvent.FromEvent(new ZigbeeAttributeReportReceivedEvent(1, "ieee-1", 1, 1, 0, 0, null))
+        );
+
+        Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeAttributeReportReceivedEvent.Type);
+    }
+
+    [Fact]
+    public async Task WhenCommandSentEventReceivedThenActivityIsRecorded()
+    {
+        await _hausBus.PublishAsync(RoutableEvent.FromEvent(new ZigbeeCommandSentEvent(1, "ieee-1", 1, 1)));
+
+        Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeCommandSentEvent.Type);
+    }
+
+    [Fact]
+    public async Task WhenTransportErrorEventReceivedThenActivityIsRecorded()
+    {
+        await _hausBus.PublishAsync(
+            RoutableEvent.FromEvent(new ZigbeeTransportErrorEvent("timeout", "boom", 1, "ieee-1"))
+        );
+
+        Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeTransportErrorEvent.Type);
+    }
+}

--- a/tests/Haus.Core.Tests/Zigbee/Queries/ZigbeeQueriesTests.cs
+++ b/tests/Haus.Core.Tests/Zigbee/Queries/ZigbeeQueriesTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.Queries;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs;
+using Haus.Testing.Support;
+using Xunit;
+
+namespace Haus.Core.Tests.Zigbee.Queries;
+
+public class ZigbeeQueriesTests
+{
+    private readonly IHausBus _hausBus;
+    private readonly IZigbeeStore _store;
+
+    public ZigbeeQueriesTests()
+    {
+        _store = new ZigbeeStore();
+        _hausBus = HausBusFactory.Create(configureServices: services => services.Replace<IZigbeeStore>(_store));
+    }
+
+    [Fact]
+    public async Task WhenGettingConnectionStatusThenReturnsCurrentConnectionStatus()
+    {
+        var status = new ZigbeeConnectionStatusModel(true, "connected", DateTimeOffset.UtcNow);
+        _store.Publish(_store.Current.UpdateConnectionStatus(status));
+
+        var result = await _hausBus.ExecuteQueryAsync(new GetZigbeeConnectionStatusQuery());
+
+        Assert.Equal(status, result);
+    }
+
+    [Fact]
+    public async Task WhenGettingRecentActivityThenReturnsRecordedActivity()
+    {
+        var entry = new ZigbeeActivityEntryModel("some_type", DateTimeOffset.UtcNow, new { });
+        _store.Publish(_store.Current.RecordActivity(entry));
+
+        var result = await _hausBus.ExecuteQueryAsync(new GetRecentZigbeeActivityQuery());
+
+        Assert.Contains(entry, result.Items);
+    }
+
+    [Fact]
+    public async Task WhenGettingKnownDevicesThenReturnsKnownDevices()
+    {
+        _store.Publish(_store.Current.RecordDeviceJoined("ieee-1", 42, DateTimeOffset.UtcNow));
+
+        var result = await _hausBus.ExecuteQueryAsync(new GetKnownZigbeeDevicesQuery());
+
+        Assert.Contains(result.Items, d => d.IeeeAddress == "ieee-1");
+    }
+}

--- a/tests/Haus.Core.Tests/Zigbee/State/ZigbeeStateTests.cs
+++ b/tests/Haus.Core.Tests/Zigbee/State/ZigbeeStateTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.State;
+using Xunit;
+
+namespace Haus.Core.Tests.Zigbee.State;
+
+public class ZigbeeStateTests
+{
+    [Fact]
+    public void WhenInitialThenConnectionStatusIsUnknown()
+    {
+        Assert.Equal(ZigbeeConnectionStatusModel.Unknown, ZigbeeState.Initial.ConnectionStatus);
+    }
+
+    [Fact]
+    public void WhenConnectionStatusIsUpdatedThenStateHasNewStatus()
+    {
+        var status = new ZigbeeConnectionStatusModel(true, "connected", DateTimeOffset.UtcNow);
+
+        var state = ZigbeeState.Initial.UpdateConnectionStatus(status);
+
+        Assert.Equal(status, state.ConnectionStatus);
+    }
+
+    [Fact]
+    public void WhenActivityIsRecordedThenStateHasActivity()
+    {
+        var entry = new ZigbeeActivityEntryModel("some_type", DateTimeOffset.UtcNow, new { });
+
+        var state = ZigbeeState.Initial.RecordActivity(entry);
+
+        Assert.Contains(entry, state.RecentActivity);
+    }
+
+    [Fact]
+    public void WhenActivityCountExceedsMaxThenOldestActivityIsDropped()
+    {
+        var state = Enumerable
+            .Range(0, ZigbeeState.MaxRecentActivity + 1)
+            .Aggregate(
+                (IZigbeeState)ZigbeeState.Initial,
+                (s, i) => s.RecordActivity(new ZigbeeActivityEntryModel($"type-{i}", DateTimeOffset.UtcNow, i))
+            );
+
+        Assert.Equal(ZigbeeState.MaxRecentActivity, state.RecentActivity.Length);
+        Assert.DoesNotContain(state.RecentActivity, e => e.EventType == "type-0");
+        Assert.Contains(state.RecentActivity, e => e.EventType == $"type-{ZigbeeState.MaxRecentActivity}");
+    }
+
+    [Fact]
+    public void WhenDeviceJoinedThenKnownDevicesHasDeviceWithNetworkAddress()
+    {
+        var seenAt = DateTimeOffset.UtcNow;
+
+        var state = ZigbeeState.Initial.RecordDeviceJoined("ieee-1", 42, seenAt);
+
+        var device = Assert.Single(state.KnownDevices.Values);
+        Assert.Equal("ieee-1", device.IeeeAddress);
+        Assert.Equal((ushort)42, device.NetworkAddress);
+        Assert.Equal(seenAt, device.LastSeenAt);
+    }
+
+    [Fact]
+    public void WhenDeviceInfoDiscoveredAfterJoinThenExistingDeviceIsAugmentedNotReplaced()
+    {
+        var joinedAt = DateTimeOffset.UtcNow;
+        var discoveredAt = joinedAt.AddSeconds(1);
+        var endpoints = ImmutableArray<ZigbeeEndpointModel>.Empty;
+
+        var state = ZigbeeState
+            .Initial.RecordDeviceJoined("ieee-1", 42, joinedAt)
+            .RecordDeviceInfoDiscovered("ieee-1", "Acme", "Widget", endpoints, discoveredAt);
+
+        var device = Assert.Single(state.KnownDevices.Values);
+        Assert.Equal((ushort)42, device.NetworkAddress);
+        Assert.Equal("Acme", device.ManufacturerName);
+        Assert.Equal("Widget", device.ModelIdentifier);
+        Assert.Equal(discoveredAt, device.LastSeenAt);
+    }
+
+    [Fact]
+    public void WhenDeviceInfoDiscoveredWithoutPriorJoinThenDeviceIsAddedWithNoNetworkAddress()
+    {
+        var state = ZigbeeState.Initial.RecordDeviceInfoDiscovered(
+            "ieee-2",
+            "Acme",
+            "Widget",
+            ImmutableArray<ZigbeeEndpointModel>.Empty,
+            DateTimeOffset.UtcNow
+        );
+
+        var device = Assert.Single(state.KnownDevices.Values);
+        Assert.Null(device.NetworkAddress);
+    }
+}

--- a/tests/Haus.Core.Tests/Zigbee/State/ZigbeeStoreTests.cs
+++ b/tests/Haus.Core.Tests/Zigbee/State/ZigbeeStoreTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reactive.Linq;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Zigbee.State;
+using Xunit;
+
+namespace Haus.Core.Tests.Zigbee.State;
+
+public class ZigbeeStoreTests
+{
+    [Fact]
+    public void WhenCreatedThenInitialState()
+    {
+        var store = new ZigbeeStore();
+
+        Assert.Equal(ZigbeeState.Initial, store.Current);
+    }
+
+    [Fact]
+    public void WhenPublishedThenCurrentStateIsUpdated()
+    {
+        var status = new ZigbeeConnectionStatusModel(true, "connected", DateTimeOffset.UtcNow);
+
+        var store = new ZigbeeStore();
+        store.Publish(store.Current.UpdateConnectionStatus(status));
+
+        Assert.Equal(status, store.Current.ConnectionStatus);
+    }
+
+    [Fact]
+    public void WhenPublishNextIsUsedAndNewStateIsUnchangedThenNoUpdatesAreSent()
+    {
+        var publishCount = 0;
+
+        var store = new ZigbeeStore();
+        store.Skip(1).Subscribe(s => publishCount++);
+
+        store.PublishNext(s => s);
+
+        Assert.Equal(0, publishCount);
+    }
+}

--- a/tests/Haus.Web.Host.Tests/Support/HausWebHostApplicationFactory.cs
+++ b/tests/Haus.Web.Host.Tests/Support/HausWebHostApplicationFactory.cs
@@ -164,6 +164,12 @@ public class HausWebHostApplicationFactory : WebApplicationFactory<Startup>
         await client.PublishHausEventAsync(creator);
     }
 
+    public async Task PublishZigbeeEventAsync<T>(IHausEventCreator<T> creator)
+    {
+        var client = await GetMqttClient();
+        await client.PublishHausEventAsync(creator, DefaultHausMqttTopics.ZigbeeTopic);
+    }
+
     public async Task<DeviceModel> WaitForDeviceToBeDiscovered(
         DeviceType deviceType = DeviceType.Unknown,
         string? externalId = null

--- a/tests/Haus.Web.Host.Tests/Zigbee/ZigbeeApiTests.cs
+++ b/tests/Haus.Web.Host.Tests/Zigbee/ZigbeeApiTests.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Haus.Api.Client;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Testing.Support;
+using Haus.Web.Host.Tests.Support;
+using Xunit;
+
+namespace Haus.Web.Host.Tests.Zigbee;
+
+[Collection(HausWebHostCollectionFixture.Name)]
+public class ZigbeeApiTests(HausWebHostApplicationFactory factory)
+{
+    private readonly IHausApiClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task WhenConnectionStatusChangedEventPublishedThenStatusEndpointReflectsIt()
+    {
+        await factory.PublishZigbeeEventAsync(new ZigbeeConnectionStatusChangedEvent(true, null, "connected"));
+
+        await Eventually.AssertAsync(async () =>
+        {
+            var status = await _client.GetZigbeeStatusAsync();
+            Assert.NotNull(status);
+            Assert.True(status.IsConnected);
+            Assert.Equal("connected", status.Reason);
+        });
+    }
+
+    [Fact]
+    public async Task WhenZigbeeEventsPublishedThenActivityEndpointHasThem()
+    {
+        var ieeeAddress = $"{System.Guid.NewGuid()}";
+        await factory.PublishZigbeeEventAsync(new ZigbeeDeviceJoinedEvent(ieeeAddress, 7));
+
+        await Eventually.AssertAsync(async () =>
+        {
+            var activity = await _client.GetZigbeeActivityAsync();
+            Assert.Contains(activity.Items, e => e.EventType == ZigbeeDeviceJoinedEvent.Type);
+        });
+    }
+
+    [Fact]
+    public async Task WhenDeviceJoinedEventPublishedThenDevicesEndpointHasKnownDevice()
+    {
+        var ieeeAddress = $"{System.Guid.NewGuid()}";
+        await factory.PublishZigbeeEventAsync(new ZigbeeDeviceJoinedEvent(ieeeAddress, 9));
+
+        await Eventually.AssertAsync(async () =>
+        {
+            var devices = await _client.GetZigbeeDevicesAsync();
+            Assert.Contains(devices.Items, d => d.IeeeAddress == ieeeAddress);
+        });
+    }
+}

--- a/tests/Haus.Web.Host.Tests/Zigbee/ZigbeeRealtimeApiTests.cs
+++ b/tests/Haus.Web.Host.Tests/Zigbee/ZigbeeRealtimeApiTests.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Haus.Core.Models.ExternalMessages;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Testing.Support;
+using Haus.Web.Host.Tests.Support;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Haus.Web.Host.Tests.Zigbee;
+
+[Collection(HausWebHostCollectionFixture.Name)]
+public class ZigbeeRealtimeApiTests(HausWebHostApplicationFactory factory)
+{
+    [Fact]
+    public async Task WhenTransportErrorEventPublishedThenBroadcastOverEventsHub()
+    {
+        var hub = await factory.CreateHubConnection("events");
+        HausEvent<ZigbeeTransportErrorEvent>? received = null;
+        hub.On<HausEvent<ZigbeeTransportErrorEvent>>(
+            "OnEvent",
+            e =>
+            {
+                if (e.Payload?.ErrorType == "timeout")
+                    received = e;
+            }
+        );
+
+        await factory.PublishZigbeeEventAsync(new ZigbeeTransportErrorEvent("timeout", "boom", 1, "ieee-1"));
+
+        Eventually.Assert(() =>
+        {
+            Assert.NotNull(received);
+            Assert.Equal("boom", received!.Payload!.Message);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Closes the visibility gap tracked in #48: `Haus.Web.Host` now consumes the `haus/zigbee` diagnostics stream (published by `Haus.Zigbee.Host` since #50) and exposes it as queryable state.

- Extends the existing `RoutableEventFactory` (the same `Type`-discriminator routing already used for `haus/events`) to recognize the six `zigbee_*` event types, rather than adding a second topic listener.
- Adds a new `Zigbee` feature folder in `Haus.Core`: an immutable `IZigbeeState`/`ZigbeeStore` (mirrors `DeviceSimulatorState`/`Store`) tracking connection status, a bounded 100-entry rolling activity log, and known devices merged from join/info-discovered events.
- Six `IEventHandler<RoutableEvent<T>>` handlers fold each event type into the store.
- Three CQRS queries (`GetZigbeeConnectionStatusQuery`, `GetRecentZigbeeActivityQuery`, `GetKnownZigbeeDevicesQuery`) expose the state through `IHausBus`.
- `ZigbeeController` exposes `GET api/zigbee/status|activity|devices`, backed by a new `IZigbeeApiClient` wired into `IHausApiClient`.
- Live broadcast reuses the existing `EventsHub` (`/hubs/events`, `OnEvent`) — since `RoutableEventsToSignalrHandler<T>` already broadcasts every `RoutableEvent<T>`, wiring the six types into the factory was sufficient; no new hub was needed.
- State is in-memory only (no persistence), per scope.

## Test plan
- [x] `dotnet test tests/Haus.Core.Tests` — 255/255 passing
- [x] `dotnet test tests/Haus.Web.Host.Tests` — 61/61 passing (excludes 3 pre-existing `ApplicationApiTests` failures unrelated to this change — they require `GITHUB_TOKEN`, not set in this sandbox)
- [x] Manually verified `GET /api/zigbee/status|activity|devices` and the `OnEvent` SignalR broadcast against a real MQTT broker via `HausWebHostApplicationFactory`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pj9UrnP43AJJVqUyaAMvaU