### PR TITLE
fix(zigbee): align ZigbeeController with HausBusController convention

### DIFF
--- a/src/Haus.Web.Host/Zigbee/ZigbeeController.cs
+++ b/src/Haus.Web.Host/Zigbee/ZigbeeController.cs
@@ -10,20 +10,20 @@ namespace Haus.Web.Host.Zigbee;
 public class ZigbeeController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet("status")]
-    public Task<IActionResult> GetStatus()
+    public async Task<IActionResult> GetStatus()
     {
-        return QueryAsync(new GetZigbeeConnectionStatusQuery());
+        return await QueryAsync(new GetZigbeeConnectionStatusQuery());
     }
 
     [HttpGet("activity")]
-    public Task<IActionResult> GetActivity()
+    public async Task<IActionResult> GetActivity()
     {
-        return QueryAsync(new GetRecentZigbeeActivityQuery());
+        return await QueryAsync(new GetRecentZigbeeActivityQuery());
     }
 
     [HttpGet("devices")]
-    public Task<IActionResult> GetDevices()
+    public async Task<IActionResult> GetDevices()
     {
-        return QueryAsync(new GetKnownZigbeeDevicesQuery());
+        return await QueryAsync(new GetKnownZigbeeDevicesQuery());
     }
 }

--- a/src/Haus.Web.Host/Zigbee/ZigbeeController.cs
+++ b/src/Haus.Web.Host/Zigbee/ZigbeeController.cs
@@ -1,33 +1,29 @@
 using System.Threading.Tasks;
-using Haus.Core.Models.Common;
-using Haus.Core.Models.Zigbee;
 using Haus.Core.Zigbee.Queries;
 using Haus.Cqrs;
-using Microsoft.AspNetCore.Authorization;
+using Haus.Web.Host.Common.Mvc;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Haus.Web.Host.Zigbee;
 
-[Authorize]
-[ApiController]
 [Route("api/zigbee")]
-public class ZigbeeController(IHausBus hausBus) : Controller
+public class ZigbeeController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet("status")]
-    public async Task<ZigbeeConnectionStatusModel> GetStatus()
+    public Task<IActionResult> GetStatus()
     {
-        return await hausBus.ExecuteQueryAsync(new GetZigbeeConnectionStatusQuery());
+        return QueryAsync(new GetZigbeeConnectionStatusQuery());
     }
 
     [HttpGet("activity")]
-    public async Task<ListResult<ZigbeeActivityEntryModel>> GetActivity()
+    public Task<IActionResult> GetActivity()
     {
-        return await hausBus.ExecuteQueryAsync(new GetRecentZigbeeActivityQuery());
+        return QueryAsync(new GetRecentZigbeeActivityQuery());
     }
 
     [HttpGet("devices")]
-    public async Task<ListResult<ZigbeeKnownDeviceModel>> GetDevices()
+    public Task<IActionResult> GetDevices()
     {
-        return await hausBus.ExecuteQueryAsync(new GetKnownZigbeeDevicesQuery());
+        return QueryAsync(new GetKnownZigbeeDevicesQuery());
     }
 }


### PR DESCRIPTION
## Summary
- Fix-forward from independent review of PR #51 (part of #48): `ZigbeeController` deviated from the convention used by every other query-backed controller (`RoomsController`, `DeviceSimulatorController`, `LogsController`, `ApplicationController`, `DiscoveryController`) — inherit `HausBusController(hausBus)` and return `Task<IActionResult>` via `QueryAsync`, instead of extending `Controller` directly and returning raw model types with redundant `[Authorize]`/`[ApiController]` attributes.
- `GetStatus`/`GetActivity`/`GetDevices` now go through `HausBusController.QueryAsync`, which centralizes auth, null→404 semantics, and validation-exception handling.
- No query/handler/store behavior changed — same JSON body on success (`QueryAsync` → `OkOrNotFound` → `Ok(model)`), and `IZigbeeApiClient` already tolerates a null/404 status.

## Test plan
- [x] `dotnet test tests/Haus.Core.Tests` — 255/255 passed
- [x] `dotnet test tests/Haus.Web.Host.Tests` (against a disposable Mosquitto broker, mirroring the Makefile's `test-unit` pattern) — Zigbee-specific tests (`ZigbeeApiTests`, `ZigbeeRealtimeApiTests`) 4/4 passed; 3 pre-existing failures in `ApplicationApiTests` are unrelated (they hit the real GitHub API and require `GITHUB_TOKEN`, which isn't set in this sandbox)
- [x] `csharpier check` clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HbLwT98FBmGWWFwgwjWdt