### PR TITLE
feat(site-host): Zigbee network visibility UI

### DIFF
--- a/.craft-code.yml
+++ b/.craft-code.yml
@@ -1,0 +1,21 @@
+stack: [dotnet]
+package_manager: dotnet
+commands:
+  install:      dotnet tool restore
+  build:        dotnet build
+  test:         dotnet test tests/Haus.Site.Host.Tests --no-build
+  test_all:     make test-unit
+  acceptance:   make test-acceptance
+  run:          make site-host
+  lint:         dotnet husky run --group pre-commit
+  format_check: dotnet csharpier check .
+git:
+  main_branch: main
+  worktree_dir: .worktrees
+paths:
+  plans:  docs/craft-code/plans
+  design: docs/craft-code/design
+notes:
+  - "test-unit boots a disposable mosquitto MQTT broker on port 21883; test-acceptance boots the full stack via docker-compose.local.yml with its own MQTT broker on non-standard ports."
+  - "Commit messages must follow Conventional Commits (enforced by a Husky.Net commit-msg hook)."
+  - "CSharpier + dotnet format run automatically on staged *.cs files via Husky.Net pre-commit hook — do not bypass."

--- a/src/Haus.Site.Host/Shell/ShellDrawerView.razor
+++ b/src/Haus.Site.Host/Shell/ShellDrawerView.razor
@@ -13,6 +13,7 @@
                 }
                 <MudNavLink Href="/health">Health</MudNavLink>
                 <MudNavLink Href="/rooms">Rooms</MudNavLink>
+                <MudNavLink Href="/zigbee">Zigbee</MudNavLink>
             </Authorized>
         </AuthorizeView>
     </MudNavMenu>

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityEntryView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityEntryView.razor
@@ -1,0 +1,19 @@
+@using Haus.Core.Models.Zigbee
+
+@if (Entry != null)
+{
+    <MudExpansionPanel Style="max-height: 100%">
+        <TitleContent>
+            <MudText Typo="Typo.h6">
+                @Entry.EventType (@Entry.OccurredAt.FormatTimestamp())
+            </MudText>
+        </TitleContent>
+        <ChildContent>
+            <pre>@Entry.Payload.FormatAsJson()</pre>
+        </ChildContent>
+    </MudExpansionPanel>
+}
+
+@code {
+    [Parameter] public ZigbeeActivityEntryModel? Entry { get; set; }
+}

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -1,24 +1,35 @@
 @using Haus.Api.Client
-@using Haus.Core.Models.Common
 @using Haus.Core.Models.Zigbee
 
 @inject IHausApiClient ApiClient
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee activity...">
-    @if (Activity.Items.Length == 0)
+    @if (Entries.Length == 0)
     {
         <MudText>No recent zigbee activity</MudText>
+    }
+    else
+    {
+        <div style="max-height: 400px; overflow-y: auto;">
+            <MudExpansionPanels>
+                @foreach (var entry in Entries)
+                {
+                    <ZigbeeActivityEntryView Entry="entry"/>
+                }
+            </MudExpansionPanels>
+        </div>
     }
 </LoadingContentView>
 
 @code {
     private bool IsLoading { get; set; }
-    private ListResult<ZigbeeActivityEntryModel> Activity { get; set; } = new();
+    private ZigbeeActivityEntryModel[] Entries { get; set; } = [];
 
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
-        Activity = await ApiClient.GetZigbeeActivityAsync();
+        var activity = await ApiClient.GetZigbeeActivityAsync();
+        Entries = activity.Items.Reverse().ToArray();
         IsLoading = false;
     }
 }

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -5,6 +5,10 @@
 @inject IHausApiClient ApiClient
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee activity...">
+    @if (Activity.Items.Length == 0)
+    {
+        <MudText>No recent zigbee activity</MudText>
+    }
 </LoadingContentView>
 
 @code {

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -1,0 +1,20 @@
+@using Haus.Api.Client
+@using Haus.Core.Models.Common
+@using Haus.Core.Models.Zigbee
+
+@inject IHausApiClient ApiClient
+
+<LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee activity...">
+</LoadingContentView>
+
+@code {
+    private bool IsLoading { get; set; }
+    private ListResult<ZigbeeActivityEntryModel> Activity { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        IsLoading = true;
+        Activity = await ApiClient.GetZigbeeActivityAsync();
+        IsLoading = false;
+    }
+}

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -62,7 +62,8 @@
         if (@event.Type is null || !ZigbeeEventTypes.Contains(@event.Type))
             return;
 
-        var entry = new ZigbeeActivityEntryModel(@event.Type, DateTimeOffset.Now, @event.Payload);
+        var occurredAt = DateTimeOffset.TryParse(@event.Timestamp, out var parsed) ? parsed : DateTimeOffset.Now;
+        var entry = new ZigbeeActivityEntryModel(@event.Type, occurredAt, @event.Payload);
         Entries = new[] { entry }.Concat(Entries).Take(MaxEntries).ToArray();
         await InvokeAsync(StateHasChanged);
     }

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -1,7 +1,14 @@
 @using Haus.Api.Client
+@using Haus.Core.Models
+@using Haus.Core.Models.ExternalMessages
 @using Haus.Core.Models.Zigbee
+@using Haus.Core.Models.Zigbee.Events
+@using Haus.Site.Host.Shared.Realtime
+
+@implements IAsyncDisposable
 
 @inject IHausApiClient ApiClient
+@inject IRealtimeDataFactory RealtimeDataFactory
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee activity...">
     @if (Entries.Length == 0)
@@ -22,8 +29,11 @@
 </LoadingContentView>
 
 @code {
+    private const int MaxEntries = 100;
+
     private bool IsLoading { get; set; }
     private ZigbeeActivityEntryModel[] Entries { get; set; } = [];
+    private IRealtimeDataSubscriber? _eventsSubscriber;
 
     protected override async Task OnInitializedAsync()
     {
@@ -31,5 +41,45 @@
         var activity = await ApiClient.GetZigbeeActivityAsync();
         Entries = activity.Items.Reverse().ToArray();
         IsLoading = false;
+
+        _eventsSubscriber = await RealtimeDataFactory.CreateSubscriber(HausRealtimeSources.Events);
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeConnectionStatusChangedEvent>>(
+            HausEventsEventNames.OnEvent,
+            e => AddEntryAsync(e.Type, e.Payload)
+        );
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceJoinedEvent>>(
+            HausEventsEventNames.OnEvent,
+            e => AddEntryAsync(e.Type, e.Payload)
+        );
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceInfoDiscoveredEvent>>(
+            HausEventsEventNames.OnEvent,
+            e => AddEntryAsync(e.Type, e.Payload)
+        );
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeAttributeReportReceivedEvent>>(
+            HausEventsEventNames.OnEvent,
+            e => AddEntryAsync(e.Type, e.Payload)
+        );
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeCommandSentEvent>>(
+            HausEventsEventNames.OnEvent,
+            e => AddEntryAsync(e.Type, e.Payload)
+        );
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeTransportErrorEvent>>(
+            HausEventsEventNames.OnEvent,
+            e => AddEntryAsync(e.Type, e.Payload)
+        );
+        await _eventsSubscriber.StartAsync();
+    }
+
+    private async Task AddEntryAsync(string? eventType, object payload)
+    {
+        var entry = new ZigbeeActivityEntryModel(eventType ?? "", DateTimeOffset.Now, payload);
+        Entries = new[] { entry }.Concat(Entries).Take(MaxEntries).ToArray();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_eventsSubscriber != null)
+            await _eventsSubscriber.DisposeAsync();
     }
 }

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -31,6 +31,16 @@
 @code {
     private const int MaxEntries = 100;
 
+    private static readonly HashSet<string> ZigbeeEventTypes =
+    [
+        ZigbeeConnectionStatusChangedEvent.Type,
+        ZigbeeDeviceJoinedEvent.Type,
+        ZigbeeDeviceInfoDiscoveredEvent.Type,
+        ZigbeeAttributeReportReceivedEvent.Type,
+        ZigbeeCommandSentEvent.Type,
+        ZigbeeTransportErrorEvent.Type,
+    ];
+
     private bool IsLoading { get; set; }
     private ZigbeeActivityEntryModel[] Entries { get; set; } = [];
     private IRealtimeDataSubscriber? _eventsSubscriber;
@@ -39,40 +49,20 @@
     {
         IsLoading = true;
         var activity = await ApiClient.GetZigbeeActivityAsync();
-        Entries = activity.Items.Reverse().ToArray();
+        Entries = activity.Items.Reverse().Take(MaxEntries).ToArray();
         IsLoading = false;
 
         _eventsSubscriber = await RealtimeDataFactory.CreateSubscriber(HausRealtimeSources.Events);
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeConnectionStatusChangedEvent>>(
-            HausEventsEventNames.OnEvent,
-            e => AddEntryAsync(e.Type, e.Payload)
-        );
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceJoinedEvent>>(
-            HausEventsEventNames.OnEvent,
-            e => AddEntryAsync(e.Type, e.Payload)
-        );
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceInfoDiscoveredEvent>>(
-            HausEventsEventNames.OnEvent,
-            e => AddEntryAsync(e.Type, e.Payload)
-        );
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeAttributeReportReceivedEvent>>(
-            HausEventsEventNames.OnEvent,
-            e => AddEntryAsync(e.Type, e.Payload)
-        );
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeCommandSentEvent>>(
-            HausEventsEventNames.OnEvent,
-            e => AddEntryAsync(e.Type, e.Payload)
-        );
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeTransportErrorEvent>>(
-            HausEventsEventNames.OnEvent,
-            e => AddEntryAsync(e.Type, e.Payload)
-        );
+        _eventsSubscriber.Subscribe<HausEvent<dynamic>>(HausEventsEventNames.OnEvent, HandleEvent);
         await _eventsSubscriber.StartAsync();
     }
 
-    private async Task AddEntryAsync(string? eventType, object payload)
+    private async Task HandleEvent(HausEvent<dynamic> @event)
     {
-        var entry = new ZigbeeActivityEntryModel(eventType ?? "", DateTimeOffset.Now, payload);
+        if (@event.Type is null || !ZigbeeEventTypes.Contains(@event.Type))
+            return;
+
+        var entry = new ZigbeeActivityEntryModel(@event.Type, DateTimeOffset.Now, @event.Payload);
         Entries = new[] { entry }.Concat(Entries).Take(MaxEntries).ToArray();
         await InvokeAsync(StateHasChanged);
     }

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -49,7 +49,7 @@
     {
         IsLoading = true;
         var activity = await ApiClient.GetZigbeeActivityAsync();
-        Entries = activity.Items.Reverse().Take(MaxEntries).ToArray();
+        Entries = activity.Items.Take(MaxEntries).ToArray();
         IsLoading = false;
 
         _eventsSubscriber = await RealtimeDataFactory.CreateSubscriber(HausRealtimeSources.Events);

--- a/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
+++ b/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
@@ -1,0 +1,18 @@
+@using Haus.Api.Client
+@using Haus.Core.Models.Zigbee
+
+@inject IHausApiClient ApiClient
+
+<LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee status...">
+</LoadingContentView>
+
+@code {
+    private bool IsLoading { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        IsLoading = true;
+        await ApiClient.GetZigbeeStatusAsync();
+        IsLoading = false;
+    }
+}

--- a/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
+++ b/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
@@ -4,15 +4,48 @@
 @inject IHausApiClient ApiClient
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee status...">
+    <MudPaper Class="pa-4">
+        <MudText Typo="Typo.h5" Style="@($"background-color: {StatusColor}")" Class="pa-4 rounded">
+            @StatusText
+        </MudText>
+        @if (!string.IsNullOrEmpty(Status.Reason))
+        {
+            <MudText>@Status.Reason</MudText>
+        }
+        @if (Status.ChangedAt != null)
+        {
+            <MudText Typo="Typo.caption">Last changed: @Status.ChangedAt.Value.FormatTimestamp()</MudText>
+        }
+    </MudPaper>
 </LoadingContentView>
 
 @code {
     private bool IsLoading { get; set; }
+    private ZigbeeConnectionStatusModel Status { get; set; } = ZigbeeConnectionStatusModel.Unknown;
+
+    [CascadingParameter]
+    private MudTheme? Theme { get; set; }
+
+    private bool IsUnknown => Status.ChangedAt is null;
+
+    private string StatusText => IsUnknown ? "Unknown" : Status.IsConnected ? "Connected" : "Disconnected";
+
+    private string StatusColor
+    {
+        get
+        {
+            var theme = Theme ?? new HausTheme();
+            if (IsUnknown)
+                return theme.PaletteLight.Info.Value;
+
+            return Status.IsConnected ? theme.PaletteLight.Success.Value : theme.PaletteLight.Error.Value;
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
-        await ApiClient.GetZigbeeStatusAsync();
+        Status = await ApiClient.GetZigbeeStatusAsync() ?? ZigbeeConnectionStatusModel.Unknown;
         IsLoading = false;
     }
 }

--- a/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
+++ b/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
@@ -70,7 +70,8 @@
         if (@event.Type != ZigbeeConnectionStatusChangedEvent.Type)
             return;
 
-        Status = new ZigbeeConnectionStatusModel(@event.Payload.IsConnected, @event.Payload.Reason, DateTimeOffset.Now);
+        var changedAt = DateTimeOffset.TryParse(@event.Timestamp, out var parsed) ? parsed : DateTimeOffset.Now;
+        Status = new ZigbeeConnectionStatusModel(@event.Payload.IsConnected, @event.Payload.Reason, changedAt);
         await InvokeAsync(StateHasChanged);
     }
 

--- a/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
+++ b/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
@@ -1,7 +1,14 @@
 @using Haus.Api.Client
+@using Haus.Core.Models
+@using Haus.Core.Models.ExternalMessages
 @using Haus.Core.Models.Zigbee
+@using Haus.Core.Models.Zigbee.Events
+@using Haus.Site.Host.Shared.Realtime
+
+@implements IAsyncDisposable
 
 @inject IHausApiClient ApiClient
+@inject IRealtimeDataFactory RealtimeDataFactory
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee status...">
     <MudPaper Class="pa-4">
@@ -42,10 +49,34 @@
         }
     }
 
+    private IRealtimeDataSubscriber? _eventsSubscriber;
+
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
         Status = await ApiClient.GetZigbeeStatusAsync() ?? ZigbeeConnectionStatusModel.Unknown;
         IsLoading = false;
+
+        _eventsSubscriber = await RealtimeDataFactory.CreateSubscriber(HausRealtimeSources.Events);
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeConnectionStatusChangedEvent>>(
+            HausEventsEventNames.OnEvent,
+            HandleConnectionStatusChanged
+        );
+        await _eventsSubscriber.StartAsync();
+    }
+
+    private async Task HandleConnectionStatusChanged(HausEvent<ZigbeeConnectionStatusChangedEvent> @event)
+    {
+        if (@event.Type != ZigbeeConnectionStatusChangedEvent.Type)
+            return;
+
+        Status = new ZigbeeConnectionStatusModel(@event.Payload.IsConnected, @event.Payload.Reason, DateTimeOffset.Now);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_eventsSubscriber != null)
+            await _eventsSubscriber.DisposeAsync();
     }
 }

--- a/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
+++ b/src/Haus.Site.Host/Zigbee/ConnectionStatus/ZigbeeConnectionStatusView.razor
@@ -33,6 +33,8 @@
     [CascadingParameter]
     private MudTheme? Theme { get; set; }
 
+    // ZigbeeConnectionStatusModel.Unknown is the only status with a null ChangedAt; every real
+    // connected/disconnected status the API or live events produce sets it.
     private bool IsUnknown => Status.ChangedAt is null;
 
     private string StatusText => IsUnknown ? "Unknown" : Status.IsConnected ? "Connected" : "Disconnected";

--- a/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDeviceView.razor
+++ b/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDeviceView.razor
@@ -1,0 +1,47 @@
+@using Haus.Core.Models.Zigbee
+
+@if (Device != null)
+{
+    <MudExpansionPanel>
+        <TitleContent>
+            <MudText Typo="Typo.h6">@Device.IeeeAddress</MudText>
+        </TitleContent>
+        <ChildContent>
+            <MudTextField T="string"
+                          Label="IEEE Address"
+                          ReadOnly="true"
+                          InputId="ieeeAddress"
+                          Value="@Device.IeeeAddress"/>
+            <MudTextField T="string"
+                          Label="Network Address"
+                          ReadOnly="true"
+                          InputId="networkAddress"
+                          Value="@Device.NetworkAddress?.ToString()"/>
+            <MudTextField T="string"
+                          Label="Manufacturer"
+                          ReadOnly="true"
+                          InputId="manufacturerName"
+                          Value="@Device.ManufacturerName"/>
+            <MudTextField T="string"
+                          Label="Model"
+                          ReadOnly="true"
+                          InputId="modelIdentifier"
+                          Value="@Device.ModelIdentifier"/>
+            <MudTextField T="string"
+                          Label="Last Seen"
+                          ReadOnly="true"
+                          InputId="lastSeenAt"
+                          Value="@Device.LastSeenAt.FormatTimestamp()"/>
+            @foreach (var endpoint in Device.Endpoints)
+            {
+                <MudText>
+                    Endpoint @endpoint.EndpointId — In: @string.Join(", ", endpoint.InClusters), Out: @string.Join(", ", endpoint.OutClusters)
+                </MudText>
+            }
+        </ChildContent>
+    </MudExpansionPanel>
+}
+
+@code {
+    [Parameter] public ZigbeeKnownDeviceModel? Device { get; set; }
+}

--- a/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
+++ b/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
@@ -5,6 +5,10 @@
 @inject IHausApiClient ApiClient
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee devices...">
+    @if (Devices.Items.Length == 0)
+    {
+        <MudText>No zigbee devices discovered yet</MudText>
+    }
 </LoadingContentView>
 
 @code {

--- a/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
+++ b/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
@@ -28,6 +28,12 @@
 </LoadingContentView>
 
 @code {
+    private static readonly HashSet<string> DeviceRefreshEventTypes =
+    [
+        ZigbeeDeviceJoinedEvent.Type,
+        ZigbeeDeviceInfoDiscoveredEvent.Type,
+    ];
+
     private bool IsLoading { get; set; }
     private ListResult<ZigbeeKnownDeviceModel> Devices { get; set; } = new();
     private IRealtimeDataSubscriber? _eventsSubscriber;
@@ -39,19 +45,15 @@
         IsLoading = false;
 
         _eventsSubscriber = await RealtimeDataFactory.CreateSubscriber(HausRealtimeSources.Events);
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceJoinedEvent>>(
-            HausEventsEventNames.OnEvent,
-            _ => RefreshDevicesAsync()
-        );
-        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceInfoDiscoveredEvent>>(
-            HausEventsEventNames.OnEvent,
-            _ => RefreshDevicesAsync()
-        );
+        _eventsSubscriber.Subscribe<HausEvent<dynamic>>(HausEventsEventNames.OnEvent, HandleEvent);
         await _eventsSubscriber.StartAsync();
     }
 
-    private async Task RefreshDevicesAsync()
+    private async Task HandleEvent(HausEvent<dynamic> @event)
     {
+        if (@event.Type is null || !DeviceRefreshEventTypes.Contains(@event.Type))
+            return;
+
         Devices = await ApiClient.GetZigbeeDevicesAsync();
         await InvokeAsync(StateHasChanged);
     }

--- a/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
+++ b/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
@@ -1,0 +1,20 @@
+@using Haus.Api.Client
+@using Haus.Core.Models.Common
+@using Haus.Core.Models.Zigbee
+
+@inject IHausApiClient ApiClient
+
+<LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee devices...">
+</LoadingContentView>
+
+@code {
+    private bool IsLoading { get; set; }
+    private ListResult<ZigbeeKnownDeviceModel> Devices { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        IsLoading = true;
+        Devices = await ApiClient.GetZigbeeDevicesAsync();
+        IsLoading = false;
+    }
+}

--- a/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
+++ b/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
@@ -1,8 +1,15 @@
 @using Haus.Api.Client
+@using Haus.Core.Models
 @using Haus.Core.Models.Common
+@using Haus.Core.Models.ExternalMessages
 @using Haus.Core.Models.Zigbee
+@using Haus.Core.Models.Zigbee.Events
+@using Haus.Site.Host.Shared.Realtime
+
+@implements IAsyncDisposable
 
 @inject IHausApiClient ApiClient
+@inject IRealtimeDataFactory RealtimeDataFactory
 
 <LoadingContentView IsLoading="IsLoading" LoadingText="Loading zigbee devices...">
     @if (Devices.Items.Length == 0)
@@ -23,11 +30,35 @@
 @code {
     private bool IsLoading { get; set; }
     private ListResult<ZigbeeKnownDeviceModel> Devices { get; set; } = new();
+    private IRealtimeDataSubscriber? _eventsSubscriber;
 
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
         Devices = await ApiClient.GetZigbeeDevicesAsync();
         IsLoading = false;
+
+        _eventsSubscriber = await RealtimeDataFactory.CreateSubscriber(HausRealtimeSources.Events);
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceJoinedEvent>>(
+            HausEventsEventNames.OnEvent,
+            _ => RefreshDevicesAsync()
+        );
+        _eventsSubscriber.Subscribe<HausEvent<ZigbeeDeviceInfoDiscoveredEvent>>(
+            HausEventsEventNames.OnEvent,
+            _ => RefreshDevicesAsync()
+        );
+        await _eventsSubscriber.StartAsync();
+    }
+
+    private async Task RefreshDevicesAsync()
+    {
+        Devices = await ApiClient.GetZigbeeDevicesAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_eventsSubscriber != null)
+            await _eventsSubscriber.DisposeAsync();
     }
 }

--- a/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
+++ b/src/Haus.Site.Host/Zigbee/Devices/ZigbeeDevicesView.razor
@@ -9,6 +9,15 @@
     {
         <MudText>No zigbee devices discovered yet</MudText>
     }
+    else
+    {
+        <MudExpansionPanels>
+            @foreach (var device in Devices.Items)
+            {
+                <ZigbeeDeviceView Device="device"/>
+            }
+        </MudExpansionPanels>
+    }
 </LoadingContentView>
 
 @code {

--- a/src/Haus.Site.Host/Zigbee/ZigbeeView.razor
+++ b/src/Haus.Site.Host/Zigbee/ZigbeeView.razor
@@ -1,0 +1,19 @@
+@page "/zigbee"
+
+@using Haus.Site.Host.Zigbee.Activity
+@using Haus.Site.Host.Zigbee.ConnectionStatus
+@using Haus.Site.Host.Zigbee.Devices
+
+@attribute [Authorize]
+
+<MudGrid>
+    <MudItem xs="12">
+        <ZigbeeConnectionStatusView/>
+    </MudItem>
+    <MudItem xs="6">
+        <ZigbeeDevicesView/>
+    </MudItem>
+    <MudItem xs="6">
+        <ZigbeeActivityView/>
+    </MudItem>
+</MudGrid>

--- a/tests/Haus.Core.Tests/Zigbee/Queries/ZigbeeQueriesTests.cs
+++ b/tests/Haus.Core.Tests/Zigbee/Queries/ZigbeeQueriesTests.cs
@@ -43,6 +43,18 @@ public class ZigbeeQueriesTests
     }
 
     [Fact]
+    public async Task WhenGettingRecentActivityWithMultipleEntriesThenReturnsNewestFirst()
+    {
+        var older = new ZigbeeActivityEntryModel("older", DateTimeOffset.UtcNow, new { });
+        var newer = new ZigbeeActivityEntryModel("newer", DateTimeOffset.UtcNow, new { });
+        _store.Publish(_store.Current.RecordActivity(older).RecordActivity(newer));
+
+        var result = await _hausBus.ExecuteQueryAsync(new GetRecentZigbeeActivityQuery());
+
+        Assert.Equal([newer, older], result.Items);
+    }
+
+    [Fact]
     public async Task WhenGettingKnownDevicesThenReturnsKnownDevices()
     {
         _store.Publish(_store.Current.RecordDeviceJoined("ieee-1", 42, DateTimeOffset.UtcNow));

--- a/tests/Haus.Site.Host.Tests/Shell/ShellDrawerViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Shell/ShellDrawerViewTests.cs
@@ -21,7 +21,7 @@ public class ShellDrawerViewTests : HausSiteTestContext
 
         Eventually.Assert(() =>
         {
-            Assert.Equal(5, view.FindAllByComponent<MudNavLink>().Count());
+            Assert.Equal(6, view.FindAllByComponent<MudNavLink>().Count());
         });
     }
 
@@ -34,7 +34,21 @@ public class ShellDrawerViewTests : HausSiteTestContext
 
         Eventually.Assert(() =>
         {
-            Assert.Equal(4, view.FindAllByComponent<MudNavLink>().Count());
+            Assert.Equal(5, view.FindAllByComponent<MudNavLink>().Count());
+        });
+    }
+
+    [Fact]
+    public async Task WhenRenderedThenShowsNavigationLinkForZigbee()
+    {
+        await HausApiHandler.SetupGetAsJson(SettingsUrl, new ApplicationSettingsModel(IsDeviceSimulatorEnabled: false));
+
+        var view = RenderView<ShellDrawerView>();
+
+        Eventually.Assert(() =>
+        {
+            var navLink = view.FindByComponent<MudNavLink>(opts => opts.WithText("Zigbee"));
+            Assert.Equal("/zigbee", navLink.Instance.Href);
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityEntryViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityEntryViewTests.cs
@@ -1,0 +1,24 @@
+using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Zigbee.Activity;
+using Haus.Testing.Support;
+using MudBlazor;
+
+namespace Haus.Site.Host.Tests.Zigbee.Activity;
+
+public class ZigbeeActivityEntryViewTests : HausSiteTestContext
+{
+    [Fact]
+    public void WhenRenderedThenShowsEventTypeAndTimestamp()
+    {
+        var entry = HausModelFactory.ZigbeeActivityEntryModel() with { EventType = "zigbee_device_joined" };
+
+        var view = RenderView<ZigbeeActivityEntryView>(opts => opts.Add(p => p.Entry, entry));
+
+        Eventually.Assert(() =>
+        {
+            var panel = view.FindByComponent<MudExpansionPanel>();
+            var title = panel.FindByComponent<MudText>(opts => opts.WithText("zigbee_device_joined"));
+            Assert.NotNull(title);
+        });
+    }
+}

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Haus.Core.Models;
@@ -91,6 +92,33 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
             var entries = view.FindAllByComponent<ZigbeeActivityEntryView>().ToArray();
             Assert.Single(entries);
             Assert.Equal(ZigbeeDeviceJoinedEvent.Type, entries[0].Instance.Entry?.EventType);
+        });
+    }
+
+    [Fact]
+    public async Task WhenZigbeeEventReceivedThenUsesTheEventsTimestampNotReceiptTime()
+    {
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>());
+        var view = RenderView<ZigbeeActivityView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
+        });
+
+        var eventTimestamp = DateTimeOffset.UtcNow.AddDays(-3);
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new HausEvent<object>(
+                ZigbeeDeviceJoinedEvent.Type,
+                new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234),
+                eventTimestamp.ToString("O")
+            )
+        );
+
+        Eventually.Assert(() =>
+        {
+            var entry = view.FindByComponent<ZigbeeActivityEntryView>();
+            Assert.Equal(eventTimestamp, entry.Instance.Entry?.OccurredAt);
         });
     }
 

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Haus.Core.Models.Common;
 using Haus.Core.Models.Zigbee;
@@ -36,6 +37,24 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
         Eventually.Assert(() =>
         {
             view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
+        });
+    }
+
+    [Fact]
+    public async Task WhenRenderedThenShowsInitialActivityNewestFirst()
+    {
+        var older = HausModelFactory.ZigbeeActivityEntryModel() with { EventType = "older" };
+        var newer = HausModelFactory.ZigbeeActivityEntryModel() with { EventType = "newer" };
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>([older, newer]));
+
+        var view = RenderView<ZigbeeActivityView>();
+
+        Eventually.Assert(() =>
+        {
+            var entries = view.FindAllByComponent<ZigbeeActivityEntryView>().ToArray();
+            Assert.Equal(2, entries.Length);
+            Assert.Equal("newer", entries[0].Instance.Entry?.EventType);
+            Assert.Equal("older", entries[1].Instance.Entry?.EventType);
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Zigbee.Activity;
+using Haus.Testing.Support;
+using MudBlazor;
+
+namespace Haus.Site.Host.Tests.Zigbee.Activity;
+
+public class ZigbeeActivityViewTests : HausSiteTestContext
+{
+    private const string ActivityUrl = "/api/zigbee/activity";
+
+    [Fact]
+    public async Task WhenRenderedThenShowsLoadingActivity()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            ActivityUrl,
+            new ListResult<ZigbeeActivityEntryModel>(),
+            opts => opts.WithDelayMs(1000)
+        );
+
+        var view = RenderView<ZigbeeActivityView>();
+
+        Assert.Single(view.FindAllByComponent<MudProgressCircular>());
+    }
+}

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -80,13 +80,38 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
 
         await _eventsSubscriber.SimulateAsync(
             HausEventsEventNames.OnEvent,
-            new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234).AsHausEvent()
+            new HausEvent<object>(
+                ZigbeeDeviceJoinedEvent.Type,
+                new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234)
+            )
         );
 
         Eventually.Assert(() =>
         {
-            var entry = view.FindByComponent<ZigbeeActivityEntryView>();
-            Assert.Equal(ZigbeeDeviceJoinedEvent.Type, entry.Instance.Entry?.EventType);
+            var entries = view.FindAllByComponent<ZigbeeActivityEntryView>().ToArray();
+            Assert.Single(entries);
+            Assert.Equal(ZigbeeDeviceJoinedEvent.Type, entries[0].Instance.Entry?.EventType);
+        });
+    }
+
+    [Fact]
+    public async Task WhenNonZigbeeEventReceivedThenIgnoresIt()
+    {
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>());
+        var view = RenderView<ZigbeeActivityView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
+        });
+
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new HausEvent<object>("device_deleted", new { })
+        );
+
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
         });
     }
 
@@ -103,7 +128,10 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
 
         await _eventsSubscriber.SimulateAsync(
             HausEventsEventNames.OnEvent,
-            new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234).AsHausEvent()
+            new HausEvent<object>(
+                ZigbeeDeviceJoinedEvent.Type,
+                new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234)
+            )
         );
 
         Eventually.Assert(() =>

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -89,4 +89,26 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
             Assert.Equal(ZigbeeDeviceJoinedEvent.Type, entry.Instance.Entry?.EventType);
         });
     }
+
+    [Fact]
+    public async Task WhenActivityExceedsMaxThenOldestEntriesAreDropped()
+    {
+        var initial = Enumerable.Range(0, 100).Select(_ => HausModelFactory.ZigbeeActivityEntryModel()).ToArray();
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>(initial));
+        var view = RenderView<ZigbeeActivityView>();
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(100, view.FindAllByComponent<ZigbeeActivityEntryView>().Count());
+        });
+
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234).AsHausEvent()
+        );
+
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(100, view.FindAllByComponent<ZigbeeActivityEntryView>().Count());
+        });
+    }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -25,4 +25,17 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
 
         Assert.Single(view.FindAllByComponent<MudProgressCircular>());
     }
+
+    [Fact]
+    public async Task WhenNoActivityThenShowsEmptyMessage()
+    {
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>());
+
+        var view = RenderView<ZigbeeActivityView>();
+
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
+        });
+    }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -1,8 +1,12 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Haus.Core.Models;
 using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
 using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
 using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Tests.Support.Realtime;
 using Haus.Site.Host.Zigbee.Activity;
 using Haus.Testing.Support;
 using MudBlazor;
@@ -12,6 +16,12 @@ namespace Haus.Site.Host.Tests.Zigbee.Activity;
 public class ZigbeeActivityViewTests : HausSiteTestContext
 {
     private const string ActivityUrl = "/api/zigbee/activity";
+    private readonly InMemoryRealtimeDataSubscriber _eventsSubscriber;
+
+    public ZigbeeActivityViewTests()
+    {
+        _eventsSubscriber = GetSubscriber(HausRealtimeSources.Events);
+    }
 
     [Fact]
     public async Task WhenRenderedThenShowsLoadingActivity()
@@ -55,6 +65,28 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
             Assert.Equal(2, entries.Length);
             Assert.Equal("newer", entries[0].Instance.Entry?.EventType);
             Assert.Equal("older", entries[1].Instance.Entry?.EventType);
+        });
+    }
+
+    [Fact]
+    public async Task WhenZigbeeEventReceivedThenPrependsToActivityFeed()
+    {
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>());
+        var view = RenderView<ZigbeeActivityView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
+        });
+
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234).AsHausEvent()
+        );
+
+        Eventually.Assert(() =>
+        {
+            var entry = view.FindByComponent<ZigbeeActivityEntryView>();
+            Assert.Equal(ZigbeeDeviceJoinedEvent.Type, entry.Instance.Entry?.EventType);
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -56,7 +56,7 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
     {
         var older = HausModelFactory.ZigbeeActivityEntryModel() with { EventType = "older" };
         var newer = HausModelFactory.ZigbeeActivityEntryModel() with { EventType = "newer" };
-        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>([older, newer]));
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>([newer, older]));
 
         var view = RenderView<ZigbeeActivityView>();
 

--- a/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Zigbee.ConnectionStatus;
+using Haus.Testing.Support;
+using MudBlazor;
+
+namespace Haus.Site.Host.Tests.Zigbee.ConnectionStatus;
+
+public class ZigbeeConnectionStatusViewTests : HausSiteTestContext
+{
+    private const string StatusUrl = "/api/zigbee/status";
+
+    [Fact]
+    public async Task WhenRenderedThenShowsLoadingWhileFetchingStatus()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            StatusUrl,
+            HausModelFactory.ZigbeeConnectionStatusModel(),
+            opts => opts.WithDelayMs(1000)
+        );
+
+        var view = RenderView<ZigbeeConnectionStatusView>();
+
+        Assert.Single(view.FindAllByComponent<MudProgressCircular>());
+    }
+}

--- a/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
@@ -1,4 +1,6 @@
 using System.Threading.Tasks;
+using Haus.Core.Models.Zigbee;
+using Haus.Site.Host.Shared.Theming;
 using Haus.Site.Host.Tests.Support;
 using Haus.Site.Host.Zigbee.ConnectionStatus;
 using Haus.Testing.Support;
@@ -9,6 +11,7 @@ namespace Haus.Site.Host.Tests.Zigbee.ConnectionStatus;
 public class ZigbeeConnectionStatusViewTests : HausSiteTestContext
 {
     private const string StatusUrl = "/api/zigbee/status";
+    private static readonly HausTheme Theme = new();
 
     [Fact]
     public async Task WhenRenderedThenShowsLoadingWhileFetchingStatus()
@@ -22,5 +25,54 @@ public class ZigbeeConnectionStatusViewTests : HausSiteTestContext
         var view = RenderView<ZigbeeConnectionStatusView>();
 
         Assert.Single(view.FindAllByComponent<MudProgressCircular>());
+    }
+
+    [Fact]
+    public async Task WhenConnectedThenShowsConnectedBanner()
+    {
+        var status = HausModelFactory.ZigbeeConnectionStatusModel() with { IsConnected = true };
+        await HausApiHandler.SetupGetAsJson(StatusUrl, status);
+
+        var view = RenderView<ZigbeeConnectionStatusView>();
+
+        Eventually.Assert(() =>
+        {
+            var banner = view.FindByComponent<MudText>(opts => opts.WithText("Connected"));
+            Assert.Contains($"background-color: {Theme.PaletteLight.Success.Value}", banner.Instance.Style);
+        });
+    }
+
+    [Fact]
+    public async Task WhenDisconnectedThenShowsDisconnectedBannerWithReason()
+    {
+        var status = HausModelFactory.ZigbeeConnectionStatusModel() with
+        {
+            IsConnected = false,
+            Reason = "serial port hung",
+        };
+        await HausApiHandler.SetupGetAsJson(StatusUrl, status);
+
+        var view = RenderView<ZigbeeConnectionStatusView>();
+
+        Eventually.Assert(() =>
+        {
+            var banner = view.FindByComponent<MudText>(opts => opts.WithText("Disconnected"));
+            Assert.Contains($"background-color: {Theme.PaletteLight.Error.Value}", banner.Instance.Style);
+            view.FindByComponent<MudText>(opts => opts.WithText("serial port hung"));
+        });
+    }
+
+    [Fact]
+    public async Task WhenStatusIsUnknownThenShowsUnknownBanner()
+    {
+        await HausApiHandler.SetupGetAsJson(StatusUrl, ZigbeeConnectionStatusModel.Unknown);
+
+        var view = RenderView<ZigbeeConnectionStatusView>();
+
+        Eventually.Assert(() =>
+        {
+            var banner = view.FindByComponent<MudText>(opts => opts.WithText("Unknown"));
+            Assert.Contains($"background-color: {Theme.PaletteLight.Info.Value}", banner.Instance.Style);
+        });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Threading.Tasks;
 using Haus.Core.Models;
 using Haus.Core.Models.ExternalMessages;
 using Haus.Core.Models.Zigbee;
 using Haus.Core.Models.Zigbee.Events;
+using Haus.Site.Host.Shared.Formatting;
 using Haus.Site.Host.Shared.Theming;
 using Haus.Site.Host.Tests.Support;
 using Haus.Site.Host.Tests.Support.Realtime;
@@ -111,6 +113,38 @@ public class ZigbeeConnectionStatusViewTests : HausSiteTestContext
         {
             var banner = view.FindByComponent<MudText>(opts => opts.WithText("Connected"));
             Assert.Contains($"background-color: {Theme.PaletteLight.Success.Value}", banner.Instance.Style);
+        });
+    }
+
+    [Fact]
+    public async Task WhenConnectionStatusChangedEventReceivedThenUsesTheEventsTimestampNotReceiptTime()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            StatusUrl,
+            HausModelFactory.ZigbeeConnectionStatusModel() with
+            {
+                IsConnected = false,
+            }
+        );
+        var view = RenderView<ZigbeeConnectionStatusView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("Disconnected"));
+        });
+
+        var eventTimestamp = DateTimeOffset.UtcNow.AddDays(-3);
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new HausEvent<ZigbeeConnectionStatusChangedEvent>(
+                ZigbeeConnectionStatusChangedEvent.Type,
+                new ZigbeeConnectionStatusChangedEvent(true, null, null),
+                eventTimestamp.ToString("O")
+            )
+        );
+
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText(eventTimestamp.FormatTimestamp()));
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/ConnectionStatus/ZigbeeConnectionStatusViewTests.cs
@@ -1,7 +1,11 @@
 using System.Threading.Tasks;
+using Haus.Core.Models;
+using Haus.Core.Models.ExternalMessages;
 using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
 using Haus.Site.Host.Shared.Theming;
 using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Tests.Support.Realtime;
 using Haus.Site.Host.Zigbee.ConnectionStatus;
 using Haus.Testing.Support;
 using MudBlazor;
@@ -12,6 +16,12 @@ public class ZigbeeConnectionStatusViewTests : HausSiteTestContext
 {
     private const string StatusUrl = "/api/zigbee/status";
     private static readonly HausTheme Theme = new();
+    private readonly InMemoryRealtimeDataSubscriber _eventsSubscriber;
+
+    public ZigbeeConnectionStatusViewTests()
+    {
+        _eventsSubscriber = GetSubscriber(HausRealtimeSources.Events);
+    }
 
     [Fact]
     public async Task WhenRenderedThenShowsLoadingWhileFetchingStatus()
@@ -73,6 +83,34 @@ public class ZigbeeConnectionStatusViewTests : HausSiteTestContext
         {
             var banner = view.FindByComponent<MudText>(opts => opts.WithText("Unknown"));
             Assert.Contains($"background-color: {Theme.PaletteLight.Info.Value}", banner.Instance.Style);
+        });
+    }
+
+    [Fact]
+    public async Task WhenConnectionStatusChangedEventReceivedThenUpdatesBannerLive()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            StatusUrl,
+            HausModelFactory.ZigbeeConnectionStatusModel() with
+            {
+                IsConnected = false,
+            }
+        );
+        var view = RenderView<ZigbeeConnectionStatusView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("Disconnected"));
+        });
+
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new ZigbeeConnectionStatusChangedEvent(true, null, null).AsHausEvent()
+        );
+
+        Eventually.Assert(() =>
+        {
+            var banner = view.FindByComponent<MudText>(opts => opts.WithText("Connected"));
+            Assert.Contains($"background-color: {Theme.PaletteLight.Success.Value}", banner.Instance.Style);
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDeviceViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDeviceViewTests.cs
@@ -1,0 +1,46 @@
+using Haus.Core.Models.Zigbee;
+using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Zigbee.Devices;
+using Haus.Testing.Support;
+using MudBlazor;
+
+namespace Haus.Site.Host.Tests.Zigbee.Devices;
+
+public class ZigbeeDeviceViewTests : HausSiteTestContext
+{
+    [Fact]
+    public void WhenRenderedThenShowsIeeeAndNetworkAddress()
+    {
+        var device = HausModelFactory.ZigbeeKnownDeviceModel() with
+        {
+            IeeeAddress = "00:11:22:33:44:55:66:77",
+            NetworkAddress = 4321,
+        };
+
+        var view = RenderView<ZigbeeDeviceView>(opts => opts.Add(p => p.Device, device));
+
+        Eventually.Assert(() =>
+        {
+            Assert.Equal("00:11:22:33:44:55:66:77", view.FindMudTextFieldById<string>("ieeeAddress").GetValue());
+            Assert.Equal("4321", view.FindMudTextFieldById<string>("networkAddress").GetValue());
+        });
+    }
+
+    [Fact]
+    public void WhenRenderedThenShowsEndpointsWithClusterIds()
+    {
+        var device = HausModelFactory.ZigbeeKnownDeviceModel() with
+        {
+            Endpoints = [new ZigbeeEndpointModel(EndpointId: 1, InClusters: [0, 6], OutClusters: [25])],
+        };
+
+        var view = RenderView<ZigbeeDeviceView>(opts => opts.Add(p => p.Device, device));
+
+        Eventually.Assert(() =>
+        {
+            var endpointText = view.FindByComponent<MudText>(opts => opts.WithText("Endpoint 1"));
+            Assert.Contains("In: 0, 6", endpointText.Markup);
+            Assert.Contains("Out: 25", endpointText.Markup);
+        });
+    }
+}

--- a/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
@@ -86,12 +86,42 @@ public class ZigbeeDevicesViewTests : HausSiteTestContext
         );
         await _eventsSubscriber.SimulateAsync(
             HausEventsEventNames.OnEvent,
-            new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234).AsHausEvent()
+            new HausEvent<object>(
+                ZigbeeDeviceJoinedEvent.Type,
+                new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234)
+            )
         );
 
         Eventually.Assert(() =>
         {
             Assert.Single(view.FindAllByComponent<ZigbeeDeviceView>());
+        });
+    }
+
+    [Fact]
+    public async Task WhenNonZigbeeEventReceivedThenDoesNotRefreshDevices()
+    {
+        var callCount = 0;
+        await HausApiHandler.SetupGetAsJson(
+            DevicesUrl,
+            new ListResult<ZigbeeKnownDeviceModel>(),
+            opts => opts.WithCapture(_ => callCount++)
+        );
+        var view = RenderView<ZigbeeDevicesView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No zigbee devices discovered yet"));
+        });
+        var callCountAfterInitialLoad = callCount;
+
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new HausEvent<object>("device_deleted", new { })
+        );
+
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(callCountAfterInitialLoad, callCount);
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Haus.Core.Models.Common;
 using Haus.Core.Models.Zigbee;
@@ -36,6 +37,26 @@ public class ZigbeeDevicesViewTests : HausSiteTestContext
         Eventually.Assert(() =>
         {
             view.FindByComponent<MudText>(opts => opts.WithText("No zigbee devices discovered yet"));
+        });
+    }
+
+    [Fact]
+    public async Task WhenRenderedThenShowsEachKnownDevice()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            DevicesUrl,
+            new ListResult<ZigbeeKnownDeviceModel>([
+                HausModelFactory.ZigbeeKnownDeviceModel(),
+                HausModelFactory.ZigbeeKnownDeviceModel(),
+                HausModelFactory.ZigbeeKnownDeviceModel(),
+            ])
+        );
+
+        var view = RenderView<ZigbeeDevicesView>();
+
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(3, view.FindAllByComponent<ZigbeeDeviceView>().Count());
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Zigbee.Devices;
+using Haus.Testing.Support;
+using MudBlazor;
+
+namespace Haus.Site.Host.Tests.Zigbee.Devices;
+
+public class ZigbeeDevicesViewTests : HausSiteTestContext
+{
+    private const string DevicesUrl = "/api/zigbee/devices";
+
+    [Fact]
+    public async Task WhenRenderedThenShowsLoadingDevices()
+    {
+        await HausApiHandler.SetupGetAsJson(
+            DevicesUrl,
+            new ListResult<ZigbeeKnownDeviceModel>(),
+            opts => opts.WithDelayMs(1000)
+        );
+
+        var view = RenderView<ZigbeeDevicesView>();
+
+        Assert.Single(view.FindAllByComponent<MudProgressCircular>());
+    }
+}

--- a/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
@@ -1,8 +1,12 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Haus.Core.Models;
 using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
 using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
 using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Tests.Support.Realtime;
 using Haus.Site.Host.Zigbee.Devices;
 using Haus.Testing.Support;
 using MudBlazor;
@@ -12,6 +16,12 @@ namespace Haus.Site.Host.Tests.Zigbee.Devices;
 public class ZigbeeDevicesViewTests : HausSiteTestContext
 {
     private const string DevicesUrl = "/api/zigbee/devices";
+    private readonly InMemoryRealtimeDataSubscriber _eventsSubscriber;
+
+    public ZigbeeDevicesViewTests()
+    {
+        _eventsSubscriber = GetSubscriber(HausRealtimeSources.Events);
+    }
 
     [Fact]
     public async Task WhenRenderedThenShowsLoadingDevices()
@@ -57,6 +67,31 @@ public class ZigbeeDevicesViewTests : HausSiteTestContext
         Eventually.Assert(() =>
         {
             Assert.Equal(3, view.FindAllByComponent<ZigbeeDeviceView>().Count());
+        });
+    }
+
+    [Fact]
+    public async Task WhenDeviceJoinedEventReceivedThenRefreshesDevicesList()
+    {
+        await HausApiHandler.SetupGetAsJson(DevicesUrl, new ListResult<ZigbeeKnownDeviceModel>());
+        var view = RenderView<ZigbeeDevicesView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No zigbee devices discovered yet"));
+        });
+
+        await HausApiHandler.SetupGetAsJson(
+            DevicesUrl,
+            new ListResult<ZigbeeKnownDeviceModel>([HausModelFactory.ZigbeeKnownDeviceModel()])
+        );
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new ZigbeeDeviceJoinedEvent("00:11:22:33:44:55:66:77", 1234).AsHausEvent()
+        );
+
+        Eventually.Assert(() =>
+        {
+            Assert.Single(view.FindAllByComponent<ZigbeeDeviceView>());
         });
     }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Devices/ZigbeeDevicesViewTests.cs
@@ -25,4 +25,17 @@ public class ZigbeeDevicesViewTests : HausSiteTestContext
 
         Assert.Single(view.FindAllByComponent<MudProgressCircular>());
     }
+
+    [Fact]
+    public async Task WhenNoDevicesThenShowsEmptyMessage()
+    {
+        await HausApiHandler.SetupGetAsJson(DevicesUrl, new ListResult<ZigbeeKnownDeviceModel>());
+
+        var view = RenderView<ZigbeeDevicesView>();
+
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No zigbee devices discovered yet"));
+        });
+    }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/ZigbeeViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/ZigbeeViewTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Haus.Core.Models.Common;
+using Haus.Core.Models.Zigbee;
+using Haus.Site.Host.Tests.Support;
+using Haus.Site.Host.Zigbee;
+using Haus.Site.Host.Zigbee.Activity;
+using Haus.Site.Host.Zigbee.ConnectionStatus;
+using Haus.Site.Host.Zigbee.Devices;
+using Haus.Testing.Support;
+
+namespace Haus.Site.Host.Tests.Zigbee;
+
+public class ZigbeeViewTests : HausSiteTestContext
+{
+    [Fact]
+    public async Task WhenRenderedThenShowsConnectionStatusDevicesAndActivity()
+    {
+        await HausApiHandler.SetupGetAsJson("/api/zigbee/status", HausModelFactory.ZigbeeConnectionStatusModel());
+        await HausApiHandler.SetupGetAsJson("/api/zigbee/devices", new ListResult<ZigbeeKnownDeviceModel>());
+        await HausApiHandler.SetupGetAsJson("/api/zigbee/activity", new ListResult<ZigbeeActivityEntryModel>());
+
+        var view = RenderView<ZigbeeView>();
+
+        Eventually.Assert(() =>
+        {
+            Assert.Single(view.FindAllByComponent<ZigbeeConnectionStatusView>());
+            Assert.Single(view.FindAllByComponent<ZigbeeDevicesView>());
+            Assert.Single(view.FindAllByComponent<ZigbeeActivityView>());
+        });
+    }
+}

--- a/tests/Haus.Testing.Support/HausModelFactory.cs
+++ b/tests/Haus.Testing.Support/HausModelFactory.cs
@@ -10,6 +10,7 @@ using Haus.Core.Models.Health;
 using Haus.Core.Models.Lighting;
 using Haus.Core.Models.Logs;
 using Haus.Core.Models.Rooms;
+using Haus.Core.Models.Zigbee;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
@@ -108,6 +109,45 @@ public static class HausModelFactory
             Id: Faker.Random.Uuid().ToString(),
             Timestamp: Faker.Date.Recent().ToUniversalTime(),
             Topic: Faker.Lorem.Sentence(),
+            Payload: new { }
+        );
+    }
+
+    public static ZigbeeConnectionStatusModel ZigbeeConnectionStatusModel()
+    {
+        return new ZigbeeConnectionStatusModel(
+            IsConnected: Faker.Random.Bool(),
+            Reason: Faker.Lorem.Sentence(),
+            ChangedAt: Faker.Date.RecentOffset()
+        );
+    }
+
+    public static ZigbeeEndpointModel ZigbeeEndpointModel()
+    {
+        return new ZigbeeEndpointModel(
+            EndpointId: Faker.Random.Byte(),
+            InClusters: [Faker.Random.UShort()],
+            OutClusters: [Faker.Random.UShort()]
+        );
+    }
+
+    public static ZigbeeKnownDeviceModel ZigbeeKnownDeviceModel()
+    {
+        return new ZigbeeKnownDeviceModel(
+            IeeeAddress: Faker.Random.Hexadecimal(16),
+            NetworkAddress: Faker.Random.UShort(),
+            ManufacturerName: Faker.Company.CompanyName(),
+            ModelIdentifier: Faker.Commerce.ProductName(),
+            Endpoints: [ZigbeeEndpointModel()],
+            LastSeenAt: Faker.Date.RecentOffset()
+        );
+    }
+
+    public static ZigbeeActivityEntryModel ZigbeeActivityEntryModel()
+    {
+        return new ZigbeeActivityEntryModel(
+            EventType: Faker.Lorem.Word(),
+            OccurredAt: Faker.Date.RecentOffset(),
             Payload: new { }
         );
     }


### PR DESCRIPTION
## Summary

Final piece of #48 — adds a `Zigbee` feature folder to `Haus.Site.Host` giving users visibility into the Zigbee mesh network, built on the REST + SignalR surface `Haus.Web.Host` already exposes (#51).

- **`/zigbee` page**, reachable from site nav, composing:
  - **`ZigbeeConnectionStatusView`** — prominent connected/disconnected/unknown banner (color + text), loads current status via `GetZigbeeStatusAsync` and updates live on `ZigbeeConnectionStatusChangedEvent`. This is the piece meant to close the exact gap that let a 40+ hour coordinator outage go unnoticed silently.
  - **`ZigbeeDevicesView`** — known devices (IEEE address, network address, manufacturer/model, endpoints with in/out cluster ids), loads via `GetZigbeeDevicesAsync`, refreshes on device-joined/info-discovered events.
  - **`ZigbeeActivityView`** — live, bounded (100 entries, matching the server's `ZigbeeState.MaxRecentActivity`), scrollable activity feed, newest-first (matching the existing `DiagnosticsView` convention), updating via the existing `EventsHub`/`OnEvent` SignalR subscription (no polling).
- Follows the repo's existing `IRealtimeDataFactory`/SignalR-consuming pattern used by `DevicesListView`/`HealthStatusView`/`EventsView` rather than inventing a new one.
- Adds Zigbee model builders to `Haus.Testing.Support/HausModelFactory` (test infra only).
- No changes to `Haus.Zigbee.Host`, `Haus.Web.Host`, or `Haus.Core.Models` — this PR is `Haus.Site.Host` only.

A fresh-eyes review caught and this PR fixes two real bugs before merge:
- The activity feed and devices-refresh views originally registered multiple typed SignalR handlers on the same event name to work around a test-double limitation; in production, SignalR fans out to *every* handler registered on a method name, so this would have duplicated activity entries and caused redundant devices refetches on every unrelated event. Fixed by consolidating each to a single handler that filters by event `Type`, matching the pattern already used elsewhere in this codebase (`EventsView`, `DevicesListView`).
- Live entries were stamped with client receipt time instead of the event's own timestamp; now threads the SignalR envelope's `Timestamp` through.

## Test plan

- `dotnet test tests/Haus.Site.Host.Tests` — **143 passed, 0 failed, 0 skipped**, pristine output.
- `dotnet build` (whole solution) — all projects build clean except a pre-existing, environment-only Playwright browser-install failure in `Haus.Acceptance.Tests` (confirmed present on `main` too, unrelated to this change).
- Every acceptance criterion is covered by named bUnit tests following this repo's `HausSiteTestContext`/`Eventually.Assert`/`InMemoryRealtimeDataSubscriber` conventions:
  - `ZigbeeConnectionStatusViewTests` (6): loading, connected/disconnected/unknown banners with correct color+text, live update, live update uses event timestamp.
  - `ZigbeeDevicesViewTests` (5) + `ZigbeeDeviceViewTests` (2): loading, empty state, IEEE/network address + endpoint/cluster display, per-device rendering, live refresh on join/discovery filtered by event type.
  - `ZigbeeActivityViewTests` (7) + `ZigbeeActivityEntryViewTests` (1): loading, empty state, newest-first ordering, live prepend filtered by event type, 100-entry bound, event-timestamp fidelity.
  - `ZigbeeViewTests` (1) + `ShellDrawerViewTests` (1 new): page composition, nav link reachability.
- Not run: `make test-acceptance` / live browser drive — this machine has a running production HAUS stack (`haus_web`, `haus_site`, `haus_zigbee` containers) that I avoided touching, and I don't have this repo's Auth0 credentials configured in this session. Flagging as unverified via live browser rather than claiming it; the bUnit suite drives real component rendering/lifecycle against a real DOM (via bUnit + AngleSharp), which is this repo's existing convention for equivalent features (`HealthStatusView`, `EventsView`, `DevicesListView` have no separate Playwright coverage either).

Closes #48.