### PR TITLE
refactor(web-host): await pass-through controller actions for correct stack traces

### DIFF
--- a/src/Haus.Web.Host/Application/ApplicationController.cs
+++ b/src/Haus.Web.Host/Application/ApplicationController.cs
@@ -23,15 +23,15 @@ public class ApplicationController(IHausBus hausBus, IOptions<DeviceSimulatorOpt
     }
 
     [HttpGet("latest-version")]
-    public Task<IActionResult> GetLatestVersion()
+    public async Task<IActionResult> GetLatestVersion()
     {
-        return QueryAsync(new GetLatestVersionQuery());
+        return await QueryAsync(new GetLatestVersionQuery());
     }
 
     [HttpGet("latest-version/packages")]
-    public Task<IActionResult> GetLatestPackages()
+    public async Task<IActionResult> GetLatestPackages()
     {
-        return QueryAsync(new GetLatestVersionPackagesQuery());
+        return await QueryAsync(new GetLatestVersionPackagesQuery());
     }
 
     [HttpGet("latest-version/packages/{id}/download")]

--- a/src/Haus.Web.Host/DeviceSimulator/DeviceSimulatorController.cs
+++ b/src/Haus.Web.Host/DeviceSimulator/DeviceSimulatorController.cs
@@ -11,20 +11,20 @@ namespace Haus.Web.Host.DeviceSimulator;
 public class DeviceSimulatorController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpPost("devices")]
-    public Task<IActionResult> AddDevice([FromBody] SimulatedDeviceModel model)
+    public async Task<IActionResult> AddDevice([FromBody] SimulatedDeviceModel model)
     {
-        return CommandAsync(new CreateSimulatedDeviceCommand(model));
+        return await CommandAsync(new CreateSimulatedDeviceCommand(model));
     }
 
     [HttpPost("devices/{id}/trigger-occupancy-change")]
-    public Task<IActionResult> TriggerOccupancyChange([FromRoute] string id)
+    public async Task<IActionResult> TriggerOccupancyChange([FromRoute] string id)
     {
-        return CommandAsync(new TriggerOccupancyChangedCommand(id));
+        return await CommandAsync(new TriggerOccupancyChangedCommand(id));
     }
 
     [HttpPost("reset")]
-    public Task<IActionResult> Reset()
+    public async Task<IActionResult> Reset()
     {
-        return CommandAsync(new ResetDeviceSimulatorCommand());
+        return await CommandAsync(new ResetDeviceSimulatorCommand());
     }
 }

--- a/src/Haus.Web.Host/Devices/DeviceTypesController.cs
+++ b/src/Haus.Web.Host/Devices/DeviceTypesController.cs
@@ -10,8 +10,8 @@ namespace Haus.Web.Host.Devices;
 public class DeviceTypesController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet]
-    public Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll()
     {
-        return QueryAsync(new GetDeviceTypesQuery());
+        return await QueryAsync(new GetDeviceTypesQuery());
     }
 }

--- a/src/Haus.Web.Host/Devices/DevicesController.cs
+++ b/src/Haus.Web.Host/Devices/DevicesController.cs
@@ -13,50 +13,53 @@ namespace Haus.Web.Host.Devices;
 public class DevicesController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet("")]
-    public Task<IActionResult> Get([FromQuery] string? externalId = null)
+    public async Task<IActionResult> Get([FromQuery] string? externalId = null)
     {
-        return QueryAsync(new GetDevicesQuery(externalId));
+        return await QueryAsync(new GetDevicesQuery(externalId));
     }
 
     [HttpGet("{id}")]
-    public Task<IActionResult> GetById([FromRoute] long id)
+    public async Task<IActionResult> GetById([FromRoute] long id)
     {
-        return QueryAsync(new GetDeviceByIdQuery(id));
+        return await QueryAsync(new GetDeviceByIdQuery(id));
     }
 
     [HttpPut("{id}/lighting")]
-    public Task<IActionResult> ChangeLighting([FromRoute] long id, [FromBody] LightingModel model)
+    public async Task<IActionResult> ChangeLighting([FromRoute] long id, [FromBody] LightingModel model)
     {
-        return CommandAsync(new ChangeDeviceLightingCommand(id, model));
+        return await CommandAsync(new ChangeDeviceLightingCommand(id, model));
     }
 
     [HttpPut("{id}/lighting-constraints")]
-    public Task<IActionResult> ChangeLightingConstraints([FromRoute] long id, [FromBody] LightingConstraintsModel model)
+    public async Task<IActionResult> ChangeLightingConstraints(
+        [FromRoute] long id,
+        [FromBody] LightingConstraintsModel model
+    )
     {
-        return CommandAsync(new ChangeDeviceLightingConstraintsCommand(id, model));
+        return await CommandAsync(new ChangeDeviceLightingConstraintsCommand(id, model));
     }
 
     [HttpPost("{id}/turn-off")]
-    public Task<IActionResult> TurnOff([FromRoute] long id)
+    public async Task<IActionResult> TurnOff([FromRoute] long id)
     {
-        return CommandAsync(new TurnDeviceOffCommand(id));
+        return await CommandAsync(new TurnDeviceOffCommand(id));
     }
 
     [HttpPost("{id}/turn-on")]
-    public Task<IActionResult> TurnOn([FromRoute] long id)
+    public async Task<IActionResult> TurnOn([FromRoute] long id)
     {
-        return CommandAsync(new TurnDeviceOnCommand(id));
+        return await CommandAsync(new TurnDeviceOnCommand(id));
     }
 
     [HttpPut("{id}")]
-    public Task<IActionResult> Update([FromRoute] long id, [FromBody] DeviceModel model)
+    public async Task<IActionResult> Update([FromRoute] long id, [FromBody] DeviceModel model)
     {
-        return CommandAsync(new UpdateDeviceCommand(model with { Id = id }));
+        return await CommandAsync(new UpdateDeviceCommand(model with { Id = id }));
     }
 
     [HttpDelete("{id}")]
-    public Task<IActionResult> Delete([FromRoute] long id)
+    public async Task<IActionResult> Delete([FromRoute] long id)
     {
-        return CommandAsync(new DeleteDeviceCommand(id));
+        return await CommandAsync(new DeleteDeviceCommand(id));
     }
 }

--- a/src/Haus.Web.Host/Devices/LightTypesController.cs
+++ b/src/Haus.Web.Host/Devices/LightTypesController.cs
@@ -10,8 +10,8 @@ namespace Haus.Web.Host.Devices;
 public class LightTypesController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet]
-    public Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll()
     {
-        return QueryAsync(new GetLightTypesQuery());
+        return await QueryAsync(new GetLightTypesQuery());
     }
 }

--- a/src/Haus.Web.Host/Discovery/DiscoveryController.cs
+++ b/src/Haus.Web.Host/Discovery/DiscoveryController.cs
@@ -11,26 +11,26 @@ namespace Haus.Web.Host.Discovery;
 public class DiscoveryController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet("state")]
-    public Task<IActionResult> GetDiscovery()
+    public async Task<IActionResult> GetDiscovery()
     {
-        return QueryAsync(new GetDiscoveryQuery());
+        return await QueryAsync(new GetDiscoveryQuery());
     }
 
     [HttpPost("start")]
-    public Task<IActionResult> StartDiscovery()
+    public async Task<IActionResult> StartDiscovery()
     {
-        return CommandAsync(new StartDiscoveryCommand());
+        return await CommandAsync(new StartDiscoveryCommand());
     }
 
     [HttpPost("stop")]
-    public Task<IActionResult> StopDiscovery()
+    public async Task<IActionResult> StopDiscovery()
     {
-        return CommandAsync(new StopDiscoveryCommand());
+        return await CommandAsync(new StopDiscoveryCommand());
     }
 
     [HttpPost("sync")]
-    public Task<IActionResult> Sync()
+    public async Task<IActionResult> Sync()
     {
-        return CommandAsync(new SyncDiscoveryCommand());
+        return await CommandAsync(new SyncDiscoveryCommand());
     }
 }

--- a/src/Haus.Web.Host/Logs/LogsController.cs
+++ b/src/Haus.Web.Host/Logs/LogsController.cs
@@ -12,7 +12,7 @@ namespace Haus.Web.Host.Logs;
 public class LogsController(IHausBus hausBus, ILogsDirectoryProvider logsDirectoryProvider) : HausBusController(hausBus)
 {
     [HttpGet]
-    public Task<IActionResult> GetLogs(
+    public async Task<IActionResult> GetLogs(
         [FromQuery] int pageSize = GetLogsParameters.DefaultPageSize,
         [FromQuery] int pageNumber = GetLogsParameters.DefaultPageNumber,
         [FromQuery] string? searchTerm = null,
@@ -23,6 +23,6 @@ public class LogsController(IHausBus hausBus, ILogsDirectoryProvider logsDirecto
             logsDirectoryProvider.GetLogsDirectory(),
             new GetLogsParameters(pageNumber, pageSize, searchTerm, level)
         );
-        return QueryAsync(query);
+        return await QueryAsync(query);
     }
 }

--- a/src/Haus.Web.Host/Rooms/RoomsController.cs
+++ b/src/Haus.Web.Host/Rooms/RoomsController.cs
@@ -13,56 +13,56 @@ namespace Haus.Web.Host.Rooms;
 public class RoomsController(IHausBus hausBus) : HausBusController(hausBus)
 {
     [HttpGet]
-    public Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll()
     {
-        return QueryAsync(new GetRoomsQuery());
+        return await QueryAsync(new GetRoomsQuery());
     }
 
     [HttpGet("{id}", Name = "GetRoomById")]
-    public Task<IActionResult> GetById([FromRoute] long id)
+    public async Task<IActionResult> GetById([FromRoute] long id)
     {
-        return QueryAsync(new GetRoomByIdQuery(id));
+        return await QueryAsync(new GetRoomByIdQuery(id));
     }
 
     [HttpPost]
-    public Task<IActionResult> Create([FromBody] RoomModel model)
+    public async Task<IActionResult> Create([FromBody] RoomModel model)
     {
-        return CreateCommandAsync(new CreateRoomCommand(model), "GetRoomById", m => new { id = m.Id });
+        return await CreateCommandAsync(new CreateRoomCommand(model), "GetRoomById", m => new { id = m.Id });
     }
 
     [HttpPut("{id}")]
-    public Task<IActionResult> Update([FromRoute] long id, [FromBody] RoomModel model)
+    public async Task<IActionResult> Update([FromRoute] long id, [FromBody] RoomModel model)
     {
-        return CommandAsync(new UpdateRoomCommand(model with { Id = id }));
+        return await CommandAsync(new UpdateRoomCommand(model with { Id = id }));
     }
 
     [HttpPost("{id}/add-devices")]
-    public Task<IActionResult> AddDevicesToRoom([FromRoute] long id, [FromBody] long[] deviceIds)
+    public async Task<IActionResult> AddDevicesToRoom([FromRoute] long id, [FromBody] long[] deviceIds)
     {
-        return CommandAsync(new AssignDevicesToRoomCommand(id, deviceIds));
+        return await CommandAsync(new AssignDevicesToRoomCommand(id, deviceIds));
     }
 
     [HttpGet("{id}/devices")]
-    public Task<IActionResult> GetDevicesInRoom([FromRoute] long id)
+    public async Task<IActionResult> GetDevicesInRoom([FromRoute] long id)
     {
-        return QueryAsync(new GetDevicesInRoomQuery(id));
+        return await QueryAsync(new GetDevicesInRoomQuery(id));
     }
 
     [HttpPut("{id}/lighting")]
-    public Task<IActionResult> ChangeLighting([FromRoute] long id, [FromBody] LightingModel model)
+    public async Task<IActionResult> ChangeLighting([FromRoute] long id, [FromBody] LightingModel model)
     {
-        return CommandAsync(new ChangeRoomLightingCommand(id, model));
+        return await CommandAsync(new ChangeRoomLightingCommand(id, model));
     }
 
     [HttpPost("{id}/turn-off")]
-    public Task<IActionResult> TurnOff([FromRoute] long id)
+    public async Task<IActionResult> TurnOff([FromRoute] long id)
     {
-        return CommandAsync(new TurnRoomOffCommand(id));
+        return await CommandAsync(new TurnRoomOffCommand(id));
     }
 
     [HttpPost("{id}/turn-on")]
-    public Task<IActionResult> TurnOn([FromRoute] long id)
+    public async Task<IActionResult> TurnOn([FromRoute] long id)
     {
-        return CommandAsync(new TurnRoomOnCommand(id));
+        return await CommandAsync(new TurnRoomOnCommand(id));
     }
 }


### PR DESCRIPTION
## Summary
- Every controller action in `Haus.Web.Host` that returned its inner `QueryAsync`/`CommandAsync`/`CreateCommandAsync` `Task<IActionResult>` directly (pass-through, no `await`) is now `async` and awaits that call — matching the pattern already applied to `ZigbeeController` in #52. This ensures exceptions thrown inside the CQRS bus carry the action method's own frame in the stack trace, instead of skipping straight from the bus call to the framework's task-scheduling machinery.
- Files touched: `Rooms/RoomsController.cs`, `DeviceSimulator/DeviceSimulatorController.cs`, `Devices/DevicesController.cs`, `Devices/DeviceTypesController.cs`, `Devices/LightTypesController.cs`, `Application/ApplicationController.cs`, `Logs/LogsController.cs`, `Discovery/DiscoveryController.cs`.
- `Common/Mvc/HausBusController.cs` (the shared `QueryAsync`/`CommandAsync`/`CreateCommandAsync` helpers) was checked for the same pattern one level down — it already awaits internally, so no change was needed. `ClientSettingsController` and `DiagnosticsController` also already await/return synchronously and were left untouched. `Zigbee/ZigbeeController.cs` is out of scope here (already fixed on #52).
- Pure mechanical refactor — same routes, same response shapes, same status codes, no behavior change.

## Test plan
Ran before and after the change, with a disposable Mosquitto broker per the Makefile's `test-unit` pattern:
- `dotnet test tests/Haus.Web.Host.Tests` — identical both before and after: **61 passed, 3 failed, 64 total** (the 3 failures are the pre-existing `ApplicationApiTests` GitHub-API tests that require `GITHUB_TOKEN`, unrelated to this change)
- `dotnet test tests/Haus.Core.Tests` — identical both before and after: **255 passed, 0 failed, 255 total**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBG7uEgmCKyAXBdf9JQUoT