### PR TITLE
fix(compose): pin explicit project names to prevent prod/dev collision

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,3 +1,8 @@
+# Explicit name: local dev/CI's project namespace must never collide with
+# the production stack's, regardless of the directory this is invoked from
+# (see docker-compose.yml's own name: for the production side of this).
+name: haus-local
+
 services:
   haus_mqtt:
     container_name: haus_mqtt_local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,10 @@
+# Explicit name: without this, Compose falls back to the containing
+# directory's basename as the project name, which is "haus" for both this
+# file's production deploy directory (/etc/haus) and this repo's checkout
+# directory -- letting `docker compose -f docker-compose.local.yml down` run
+# from the repo tear down the live production stack (see issue #41).
+name: haus
+
 services:
   haus_mqtt:
     container_name: haus_mqtt

--- a/packaging/deb/etc/haus/docker-compose.yml.template
+++ b/packaging/deb/etc/haus/docker-compose.yml.template
@@ -1,3 +1,10 @@
+# Explicit name: without this, Compose falls back to the containing
+# directory's basename ("haus", since this renders to /etc/haus) as the
+# project name. Pinning it here means the actual deployed production compose
+# file no longer depends on that inference either (see issue #41 and the
+# root docker-compose.yml's matching name:).
+name: haus
+
 services:
   haus_mqtt:
     container_name: haus_mqtt


### PR DESCRIPTION
## Summary

`docker-compose.local.yml` and `docker-compose.yml` both lacked a top-level `name:` key, so Compose fell back to the containing directory's basename as the implicit project name. This repo's checkout directory and the production deploy directory (`/etc/haus`) are both basenamed `haus`, so Compose treated the local dev/CI stack and the live production stack as the **same project**, even though `docker-compose.local.yml` uses distinct container names (`*_local`) and non-standard ports. Because `down` scopes by project name — not by the containers/file passed on the command line — running `docker compose -f docker-compose.local.yml down` from a checkout of this repo tore down the live production containers (`haus_web`, `haus_site`, `haus_zigbee`, `haus_mqtt`). This caused a real production outage.

## Changes

- `docker-compose.local.yml`: added `name: haus-local`.
- `docker-compose.yml`: added `name: haus` (belt and suspenders — pins the name it already resolved to by accident).
- `packaging/deb/etc/haus/docker-compose.yml.template`: also added `name: haus`. This is the file actually rendered to `/etc/haus/docker-compose.yml` by the `.deb` install (`DebComposeVersionPinner`/`render-deb-compose`) — the exact file involved in the incident — so it gets the same explicit pin as the root compose file. `DebComposeVersionPinner` only does string replacement on image tags, so the added `name:` line passes through the render step untouched (verified locally).
- No changes needed in the `Makefile` or CI workflows: `COMPOSE := docker compose -f docker-compose.local.yml` never passes `-p`/`--project-name` or `COMPOSE_PROJECT_NAME`, so it picks up the new explicit `name:` automatically. Confirmed no `COMPOSE_PROJECT_NAME` overrides exist anywhere in the repo.

## Verification

- `docker compose -f docker-compose.local.yml config` → `name: haus-local`
- `docker compose -f docker-compose.yml config` → `name: haus`
- Rendered `packaging/deb/etc/haus/docker-compose.yml.template` parses with `name: haus` intact.
- On a machine with a live production `haus` project stack (`/etc/haus/docker-compose.yml`, containers up 17h) and a second, unrelated worktree's local stack running under its own accidental project name, ran `docker compose -f docker-compose.local.yml down` from this worktree — confirmed via container start timestamps that the production stack and the other worktree's stack were both completely untouched.
- `dotnet build` succeeds (all projects build; the only failure in a full `make build` run is `Haus.Acceptance.Tests`' Playwright browser install needing interactive `sudo`, a pre-existing sandbox limitation unrelated to this change).

## Test plan

- [x] `docker compose -f docker-compose.local.yml config` reports project name `haus-local`
- [x] `docker compose -f docker-compose.yml config` reports project name `haus`
- [x] Booting/tearing down the local stack does not affect a separately-running `haus` project
- [x] `dotnet build` succeeds
- [x] Commit passes the Husky commit-msg (Conventional Commits) and pre-commit hooks

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147WHvE1GnNt9tLnHemutD3