### PR TITLE
ci(workflows): bump github actions runner to ubuntu-26.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   continuous_integration:
     name: Continuous Integration
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     env:
       IS_RELEASE: ${{ github.event.inputs.is_release || false }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   generate_release:
     name: Generate Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     env:
       IS_RELEASE: ${{ github.event.inputs.is_release || false }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Production now runs on ubuntu-26.04, but CI was still pinned to ubuntu-22.04. Updates the `runs-on:` value in both `.github/workflows/main.yaml` and `.github/workflows/release.yaml` to `ubuntu-26.04` so CI matches production.
- Scoped purely to the runner OS image — no other CI logic, steps, or tool versions changed. Grepped `.github/` (including the `setup-machine` composite action) for other hardcoded runner OS references; found none beyond the two `runs-on:` lines.

Closes #59

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yaml')); yaml.safe_load(open('.github/workflows/release.yaml'))"` — both files parse as valid YAML
- [ ] CI run on this PR uses ubuntu-26.04 runners successfully