### PR TITLE
feat(site-host): add lighting controls to device detail page

### DIFF
--- a/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
+++ b/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
@@ -13,7 +13,7 @@
     <MudToolBar Class="pa-0">
         <MudText Typo="Typo.h5">Device Details</MudText>
         <MudSpacer/>
-        <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="HandleDeleteClicked"/>
+        <MudIconButton Class="delete-device-button" Icon="@Icons.Material.Filled.Delete" OnClick="HandleDeleteClicked"/>
     </MudToolBar>
 
     <MudTextField T="string"

--- a/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
+++ b/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
@@ -1,9 +1,13 @@
+@using Haus.Api.Client.Devices
 @using Haus.Core.Models.Devices
+@using Haus.Core.Models.Lighting
+@using Haus.Site.Host.Shared.Lighting
 @using Haus.Site.Host.Shared.Metadata
 
 @attribute [Authorize]
 
 @inject IDialogService DialogService
+@inject IDeviceApiClient DevicesClient
 
 <MudPaper Class="pa-4 device-detail">
     <MudToolBar Class="pa-0">
@@ -48,7 +52,13 @@
         <MudPaper Class="pa-4">
             <MudText Typo="Typo.h4">Metadata</MudText>
             <EditableMetadataListView Items="Device.Metadata"/>
-        </MudPaper>    
+        </MudPaper>
+    }
+
+    @if (Device.DeviceType == DeviceType.Light)
+    {
+        <LightingView Lighting="Device.Lighting ?? new LightingModel()"
+                      OnLightingChanged="HandleLightingChanged"/>
     }
 </MudPaper>
 
@@ -59,5 +69,16 @@
     {
         var parameters = new DialogParameters<DeleteDeviceDialogView> { { x => x.Device, Device } };
         await DialogService.ShowAsync<DeleteDeviceDialogView>(null, parameters);
+    }
+
+    private async Task HandleLightingChanged(LightingModel? lighting)
+    {
+        if (lighting == null || lighting == Device.Lighting)
+        {
+            return;
+        }
+
+        await DevicesClient.ChangeDeviceLightingAsync(Device.Id, lighting);
+        Device = await DevicesClient.GetDeviceAsync(Device.Id) ?? Device;
     }
 }

--- a/tests/Haus.Acceptance.Tests/Support/Pages/DeviceDetailPage.cs
+++ b/tests/Haus.Acceptance.Tests/Support/Pages/DeviceDetailPage.cs
@@ -14,7 +14,9 @@ public class DeviceDetailPage(IPage page)
 
     public async Task DeleteAsync()
     {
-        await page.CssLocator(".device-detail .mud-icon-button").ClickAsync();
+        // A generic ".mud-icon-button" selector also matches MudSwitch's internal thumb markup
+        // (LightingView renders one for light-type devices), so target the delete button explicitly.
+        await page.CssLocator(".device-detail .delete-device-button").ClickAsync();
         var dialogTitle = page.GetByText("Delete Device");
         await page.ClickButtonAsync("Delete");
         await dialogTitle.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Hidden });

--- a/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
@@ -105,6 +105,31 @@ public class DeviceDetailViewTests : HausSiteTestContext
     }
 
     [Fact]
+    public void WhenDeviceIsLightWithFullLightingThenOnlyOneDeleteButtonIsRendered()
+    {
+        var device = HausModelFactory.DeviceModel() with
+        {
+            DeviceType = DeviceType.Light,
+            Lighting = new LightingModel(
+                State: LightingState.On,
+                Level: new LevelLightingModel(),
+                Temperature: new TemperatureLightingModel(),
+                Color: new ColorLightingModel()
+            ),
+        };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        // LightingView's MudSwitch also renders markup carrying MudBlazor's generic
+        // "mud-icon-button" class, so the delete button needs its own selector to stay
+        // uniquely identifiable (regression test for that collision).
+        Assert.Single(page.FindAll(".delete-device-button"));
+    }
+
+    [Fact]
     public void WhenDeviceTypeIsLightThenShowsLightingView()
     {
         var device = HausModelFactory.DeviceModel() with { DeviceType = DeviceType.Light };

--- a/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
@@ -1,8 +1,12 @@
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Haus.Core.Models.Common;
 using Haus.Core.Models.Devices;
+using Haus.Core.Models.Lighting;
 using Haus.Site.Host.Devices.Detail;
+using Haus.Site.Host.Shared.Lighting;
 using Haus.Site.Host.Tests.Support;
 using Haus.Testing.Support;
 using Microsoft.AspNetCore.Components.Web;
@@ -97,6 +101,66 @@ public class DeviceDetailViewTests : HausSiteTestContext
         {
             var dialog = dialogProvider.FindComponent<DeleteDeviceDialogView>();
             Assert.Equal(device, dialog.Instance.Device);
+        });
+    }
+
+    [Fact]
+    public void WhenDeviceTypeIsLightThenShowsLightingView()
+    {
+        var device = HausModelFactory.DeviceModel() with { DeviceType = DeviceType.Light };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        Assert.NotEmpty(page.FindAllByComponent<LightingView>());
+    }
+
+    [Fact]
+    public void WhenDeviceTypeIsNotLightThenDoesNotShowLightingView()
+    {
+        var device = HausModelFactory.DeviceModel() with { DeviceType = DeviceType.MotionSensor };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        Assert.Empty(page.FindAllByComponent<LightingView>());
+    }
+
+    [Fact]
+    public async Task WhenLightingIsChangedThenDeviceLightingIsUpdated()
+    {
+        HttpRequestMessage? lightingRequest = null;
+        await HausApiHandler.SetupPutAsJson(
+            "/api/devices/8/lighting",
+            new { },
+            opts => opts.WithCapture(r => lightingRequest = r)
+        );
+        var device = HausModelFactory.DeviceModel() with { Id = 8, DeviceType = DeviceType.Light };
+        await HausApiHandler.SetupGetAsJson("/api/devices/8", device);
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        var lighting = HausModelFactory.LightingModel();
+        await page.InvokeAsync(async () =>
+        {
+            await page.FindByComponent<LightingView>().Instance.OnLightingChanged.InvokeAsync(lighting);
+        });
+
+        await Eventually.AssertAsync(async () =>
+        {
+            var newLighting =
+                lightingRequest?.Content == null
+                    ? null
+                    : await lightingRequest.Content.ReadFromJsonAsync<LightingModel>();
+
+            Assert.Equal(lighting, newLighting);
         });
     }
 }


### PR DESCRIPTION
## Summary
- Render the existing `LightingView` on the device detail page when `Device.DeviceType == DeviceType.Light`, matching how `RoomDetailView` uses it (interactive, not disabled).
- Add `HandleLightingChanged` that no-ops for null/unchanged lighting, otherwise calls `IDeviceApiClient.ChangeDeviceLightingAsync` then refreshes the device via `GetDeviceAsync`, mirroring `RoomDetailView`'s pattern. Falls back to `new LightingModel()` when `Device.Lighting` is null so `LightingView` never receives a null lighting for a light-type device.
- No changes to `Haus.Core`, `Haus.Web.Host`, or `Haus.Api.Client` — the lighting command/API surface already existed end-to-end.

## Test plan
- [x] `dotnet build` — full solution builds (except pre-existing, unrelated `Haus.Acceptance.Tests` Playwright browser install failure requiring sudo in this sandbox)
- [x] `dotnet test tests/Haus.Site.Host.Tests` — 148/148 passing, including new tests:
  - `WhenDeviceTypeIsLightThenShowsLightingView`
  - `WhenDeviceTypeIsNotLightThenDoesNotShowLightingView`
  - `WhenLightingIsChangedThenDeviceLightingIsUpdated`

Co-authored-by: omnigent <noreply@omnigent.ai>