### PR TITLE
feat(devices): promote NetworkAddress to a typed field

### DIFF
--- a/src/Haus.Core.Models/Devices/DeviceModel.cs
+++ b/src/Haus.Core.Models/Devices/DeviceModel.cs
@@ -12,6 +12,7 @@ public record DeviceModel(
     DeviceType DeviceType = DeviceType.Unknown,
     LightType LightType = LightType.None,
     MetadataModel[]? Metadata = null,
+    ushort? NetworkAddress = null,
     LightingModel? Lighting = null
 ) : IdentityModel
 {

--- a/src/Haus.Core.Models/Devices/Events/DeviceDiscoveredEvent.cs
+++ b/src/Haus.Core.Models/Devices/Events/DeviceDiscoveredEvent.cs
@@ -7,7 +7,8 @@ namespace Haus.Core.Models.Devices.Events;
 public record DeviceDiscoveredEvent(
     string Id,
     DeviceType DeviceType = DeviceType.Unknown,
-    MetadataModel[]? Metadata = null
+    MetadataModel[]? Metadata = null,
+    ushort? NetworkAddress = null
 ) : IHausEventCreator<DeviceDiscoveredEvent>
 {
     public const string Type = "device_discovered";

--- a/src/Haus.Core/Common/Storage/Migrations/20260824022738_AddDeviceNetworkAddress.Designer.cs
+++ b/src/Haus.Core/Common/Storage/Migrations/20260824022738_AddDeviceNetworkAddress.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Haus.Core.Common.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Haus.Core.Common.Storage.Migrations
 {
     [DbContext(typeof(HausDbContext))]
-    partial class HausDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824022738_AddDeviceNetworkAddress")]
+    partial class AddDeviceNetworkAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Haus.Core/Common/Storage/Migrations/20260824022738_AddDeviceNetworkAddress.cs
+++ b/src/Haus.Core/Common/Storage/Migrations/20260824022738_AddDeviceNetworkAddress.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Haus.Core.Common.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceNetworkAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<ushort>(
+                name: "NetworkAddress",
+                table: "Devices",
+                type: "INTEGER",
+                nullable: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "NetworkAddress", table: "Devices");
+        }
+    }
+}

--- a/src/Haus.Core/Devices/Entities/DeviceEntity.cs
+++ b/src/Haus.Core/Devices/Entities/DeviceEntity.cs
@@ -25,6 +25,7 @@ public record DeviceEntity : Entity
         d.DeviceType,
         d.LightType,
         d.Metadata.Select(m => new MetadataModel(m.Key, m.Value)).ToArray(),
+        d.NetworkAddress,
         d.Lighting == null
             ? null
             : new LightingModel(
@@ -54,6 +55,8 @@ public record DeviceEntity : Entity
 
     public ICollection<DeviceMetadataEntity> Metadata { get; init; } = [];
 
+    public ushort? NetworkAddress { get; set; }
+
     public RoomEntity? Room { get; set; }
 
     public LightingEntity? Lighting { get; set; }
@@ -71,7 +74,8 @@ public record DeviceEntity : Entity
         LightType lightType = LightType.None,
         RoomEntity? room = null,
         LightingEntity? lighting = null,
-        ICollection<DeviceMetadataEntity>? metadata = null
+        ICollection<DeviceMetadataEntity>? metadata = null,
+        ushort? networkAddress = null
     )
     {
         Id = id;
@@ -82,6 +86,7 @@ public record DeviceEntity : Entity
         Room = room;
         Lighting = lighting ?? GenerateDefaultLighting();
         Metadata = metadata ?? new List<DeviceMetadataEntity>();
+        NetworkAddress = networkAddress;
     }
 
     public DeviceModel ToModel()
@@ -100,6 +105,7 @@ public record DeviceEntity : Entity
     {
         DeviceType = @event.DeviceType;
         LightType = GetValidLightType(@event.DeviceType, LightType);
+        NetworkAddress = @event.NetworkAddress;
         Lighting = GenerateDefaultLighting();
         if (IsLight)
             ChangeLighting(Lighting, domainEventBus);

--- a/src/Haus.Core/Devices/Entities/DeviceEntityConfiguration.cs
+++ b/src/Haus.Core/Devices/Entities/DeviceEntityConfiguration.cs
@@ -13,6 +13,7 @@ public class DeviceEntityConfiguration : IEntityTypeConfiguration<DeviceEntity>
         builder.Property(d => d.Name).IsRequired();
         builder.Property(d => d.ExternalId).IsRequired();
         builder.Property(d => d.DeviceType).IsRequired().HasConversion<string>();
+        builder.Property(d => d.NetworkAddress);
 
         builder.Ignore(d => d.IsLight);
 

--- a/src/Haus.Zigbee.Host/Zigbee/Mappers/ToHaus/DeviceJoinedMapper.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Mappers/ToHaus/DeviceJoinedMapper.cs
@@ -12,7 +12,8 @@ public class DeviceJoinedMapper(IDeviceTypeResolver deviceTypeResolver)
         return new DeviceDiscoveredEvent(
             ExternalIdConverter.ToExternalId(joined.IeeeAddress),
             deviceTypeResolver.Resolve(joined.ManufacturerName, joined.ModelIdentifier),
-            CreateMetadata(joined)
+            CreateMetadata(joined),
+            NetworkAddress: joined.NetworkAddress
         );
     }
 
@@ -31,7 +32,6 @@ public class DeviceJoinedMapper(IDeviceTypeResolver deviceTypeResolver)
         [
             new MetadataModel("vendor", joined.ManufacturerName),
             new MetadataModel("model", joined.ModelIdentifier),
-            new MetadataModel("network_address", joined.NetworkAddress.ToString()),
         ];
     }
 }

--- a/src/Haus.Zigbee.Host/Zigbee/Mappers/ToHaus/DevicesMapper.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Mappers/ToHaus/DevicesMapper.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Haus.Core.Models.Common;
 using Haus.Core.Models.Devices;
 using Haus.Core.Models.Devices.Events;
 using Haus.Zigbee.Models;
@@ -19,12 +18,7 @@ public class DevicesMapper
         return new DeviceDiscoveredEvent(
             ExternalIdConverter.ToExternalId(device.IeeeAddress),
             DeviceType.Unknown,
-            CreateMetadata(device)
+            NetworkAddress: device.NetworkAddress
         );
-    }
-
-    private static MetadataModel[] CreateMetadata(ZigbeeDevice device)
-    {
-        return [new MetadataModel("network_address", device.NetworkAddress.ToString())];
     }
 }

--- a/tests/Haus.Core.Tests/Devices/Entities/DeviceEntityTests.cs
+++ b/tests/Haus.Core.Tests/Devices/Entities/DeviceEntityTests.cs
@@ -70,6 +70,27 @@ public class DeviceEntityTest
     }
 
     [Fact]
+    public void WhenCreatedFromDeviceDiscoveredThenNetworkAddressIsSet()
+    {
+        var model = new DeviceDiscoveredEvent("this-id", NetworkAddress: 0x9abc);
+
+        var entity = DeviceEntity.FromDiscoveredDevice(model, new FakeDomainEventBus());
+
+        Assert.Equal((ushort)0x9abc, entity.NetworkAddress);
+    }
+
+    [Fact]
+    public void WhenUpdatedFromDiscoveredDeviceThenNetworkAddressIsUpdated()
+    {
+        var model = new DeviceDiscoveredEvent("", NetworkAddress: 0x1234);
+        var entity = new DeviceEntity();
+
+        entity.UpdateFromDiscoveredDevice(model, new FakeDomainEventBus());
+
+        Assert.Equal((ushort)0x1234, entity.NetworkAddress);
+    }
+
+    [Fact]
     public void WhenUpdatedFromDiscoveredDeviceToLightThenLightTypeIsLevel()
     {
         var model = new DeviceDiscoveredEvent("", DeviceType.Light);
@@ -381,7 +402,8 @@ public class DeviceEntityTest
             LightType.Level,
             new RoomEntity(89, "ignore"),
             lighting,
-            metadata
+            metadata,
+            networkAddress: 0x9abc
         );
 
         var model = device.ToModel();
@@ -394,6 +416,7 @@ public class DeviceEntityTest
         Assert.Equal(89, model.RoomId);
         Assert.Equal(lighting.ToModel(), model.Lighting);
         Assert.Equal(metadata[0].ToModel(), Assert.Single(model.Metadata));
+        Assert.Equal((ushort)0x9abc, model.NetworkAddress);
     }
 
     [Fact]

--- a/tests/Haus.Core.Tests/Devices/Queries/GetDeviceByIdQueryHandlerTests.cs
+++ b/tests/Haus.Core.Tests/Devices/Queries/GetDeviceByIdQueryHandlerTests.cs
@@ -29,6 +29,16 @@ public class GetDeviceByIdQueryHandlerTests
     }
 
     [Fact]
+    public async Task WhenDeviceHasNetworkAddressThenReturnedModelIncludesIt()
+    {
+        var device = _context.AddDevice(configure: d => d.NetworkAddress = 0x9abc);
+
+        var model = await _hausBus.ExecuteQueryAsync(new GetDeviceByIdQuery(device.Id));
+
+        Assert.Equal((ushort)0x9abc, model.NetworkAddress);
+    }
+
+    [Fact]
     public async Task WhenIdDoesNotMatchDeviceThenReturnsNull()
     {
         var model = await _hausBus.ExecuteQueryAsync(new GetDeviceByIdQuery(long.MaxValue));

--- a/tests/Haus.Testing.Support/HausModelFactory.cs
+++ b/tests/Haus.Testing.Support/HausModelFactory.cs
@@ -30,6 +30,7 @@ public static class HausModelFactory
             DeviceType: Faker.PickRandom<DeviceType>(),
             LightType: Faker.PickRandom<LightType>(),
             Metadata: [],
+            NetworkAddress: Faker.Random.UShort(),
             Lighting: null
         );
     }

--- a/tests/Haus.Web.Host.Tests/Devices/DeviceDiscoveredTests.cs
+++ b/tests/Haus.Web.Host.Tests/Devices/DeviceDiscoveredTests.cs
@@ -27,6 +27,19 @@ public class DeviceDiscoveredTests(HausWebHostApplicationFactory factory)
     }
 
     [Fact]
+    public async Task WhenDeviceDiscoveredEventReceivedThenNetworkAddressIsAvailableFromTheApi()
+    {
+        await factory.PublishHausEventAsync(new DeviceDiscoveredEvent("network-address-id", NetworkAddress: 0x9abc));
+
+        await Eventually.AssertAsync(async () =>
+        {
+            var client = factory.CreateAuthenticatedClient();
+            var list = await client.GetDevicesAsync();
+            Assert.Contains(list.Items, m => m.ExternalId == "network-address-id" && m.NetworkAddress == 0x9abc);
+        });
+    }
+
+    [Fact]
     public async Task WhenUnauthorizedThenReturnsUnauthorized()
     {
         var client = factory.CreateUnauthenticatedClient();

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Mappers/ToHaus/DeviceJoinedMapperTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Mappers/ToHaus/DeviceJoinedMapperTests.cs
@@ -50,4 +50,14 @@ public class DeviceJoinedMapperTests
         Assert.Contains(new MetadataModel("vendor", "acme"), result.Metadata);
         Assert.Contains(new MetadataModel("model", "widget-1"), result.Metadata);
     }
+
+    [Fact]
+    public void Map_SetsNetworkAddress()
+    {
+        var joined = new ZigbeeDeviceJoined(new IeeeAddress(1), 0x9abc, [], "acme", "widget-1");
+
+        var result = _mapper.Map(joined);
+
+        Assert.Equal((ushort)0x9abc, result.NetworkAddress);
+    }
 }

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Mappers/ToHaus/DevicesMapperTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Mappers/ToHaus/DevicesMapperTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Haus.Core.Models.Common;
 using Haus.Core.Models.Devices;
 using Haus.Zigbee.Host.Zigbee;
 using Haus.Zigbee.Host.Zigbee.Mappers.ToHaus;
@@ -35,13 +34,13 @@ public class DevicesMapperTests
     }
 
     [Fact]
-    public void Map_MetadataIncludesNetworkAddress()
+    public void Map_SetsNetworkAddress()
     {
         var device = new ZigbeeDevice(new IeeeAddress(1), 0x9abc, []);
 
         var result = _mapper.Map([device]).Single();
 
-        Assert.Contains(new MetadataModel("network_address", "39612"), result.Metadata);
+        Assert.Equal((ushort)0x9abc, result.NetworkAddress);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Every device's `NetworkAddress` read as `null` because it was only ever stashed in the generic `Metadata` bag under `"network_address"`.
- Adds `NetworkAddress` as a first-class nullable `ushort?` field end-to-end: `DeviceDiscoveredEvent` → `DeviceEntity` (+ EF column/migration) → `DeviceModel`, replacing the metadata-only representation (single source of truth — the `"network_address"` metadata entry is no longer emitted).

## Changes
- `Haus.Core.Models`: `DeviceDiscoveredEvent` and `DeviceModel` gain a `NetworkAddress` (`ushort?`) parameter.
- `Haus.Zigbee.Host`: `DevicesMapper` and `DeviceJoinedMapper` populate the typed field from `ZigbeeDevice`/`ZigbeeDeviceJoined` and stop emitting the `"network_address"` metadata entry.
- `Haus.Core`: `DeviceEntity` gets a `NetworkAddress` property wired through `FromDiscoveredDevice`/`UpdateFromDiscoveredDevice` and mapped in `ToModelExpression`; `DeviceEntityConfiguration` configures the new column; EF Core migration `AddDeviceNetworkAddress` adds it.
- `Haus.Testing.Support`: `HausModelFactory.DeviceModel()` now sets a `NetworkAddress` so tests aren't blind to it.
- Tests added/updated across `Haus.Zigbee.Host.Tests`, `Haus.Core.Tests`, and `Haus.Web.Host.Tests` covering the mapper → entity → EF round-trip → API GET path, and the old metadata-key assertion in `DevicesMapperTests` was replaced with a typed-field assertion.

## Test plan
- [x] `dotnet build` (full solution builds; the only failure is the unrelated `Haus.Acceptance.Tests` Playwright browser install, which needs root/sudo not available in this sandbox)
- [x] `dotnet test tests/Haus.Core.Tests` — 256 passed
- [x] `dotnet test tests/Haus.Zigbee.Host.Tests` — 82 passed
- [x] `dotnet test tests/Haus.Web.Host.Tests` — all Devices tests passed (3 unrelated pre-existing failures in `ApplicationApiTests` due to missing `GITHUB_TOKEN` in this environment)
- [x] `dotnet test tests/Haus.Site.Host.Tests` — 145 passed
- [x] `dotnet test tests/Haus.Core.Models.Tests` — 9 passed
- [x] CSharpier formatting verified via the (now-installed) pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: omnigent <noreply@omnigent.ai>