### PR TITLE
fix(zigbee-host): use NWK addressing and surface APS confirm failures for outbound commands

### DIFF
--- a/src/Haus.Zigbee.Host/Haus.Zigbee.Host.csproj
+++ b/src/Haus.Zigbee.Host/Haus.Zigbee.Host.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftPackageVersion)" />
+    <PackageReference Include="Polly" Version="8.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -26,6 +26,10 @@ public class ZigbeeOutboundRelay(
     // the overwhelming majority of commercial Zigbee lighting devices expose.
     private const byte DefaultDestinationEndpoint = 0x01;
 
+    // Per the Zigbee APS spec, a confirm status of 0x00 is APS_SUCCESS; anything else is a delivery
+    // failure reported back from the stack for that specific request.
+    private const byte SuccessConfirmStatus = 0x00;
+
     public async Task HandleCommandAsync(MqttApplicationMessage message, CancellationToken token)
     {
         var command = HausJsonSerializer.Deserialize<HausCommand>(message.PayloadSegment);
@@ -78,14 +82,17 @@ public class ZigbeeOutboundRelay(
             return;
         }
 
-        var externalId = command.Payload.Device.ExternalId;
-        if (!ExternalIdConverter.TryParseAddress(externalId, out var address))
+        var device = command.Payload.Device;
+        if (device.NetworkAddress is not { } networkAddress)
         {
-            logger.LogWarning("Cannot resolve a Zigbee address for ExternalId {@ExternalId}", externalId);
+            logger.LogWarning(
+                "Cannot send a lighting command to {@ExternalId}: no known network address",
+                device.ExternalId
+            );
             return;
         }
 
-        var destination = ApsDestination.Ieee(address, DefaultDestinationEndpoint);
+        var destination = ApsDestination.Nwk(networkAddress, DefaultDestinationEndpoint);
         var requests = lightingMapper.Map(destination, command.Payload.Lighting);
         foreach (var request in requests)
         {
@@ -93,9 +100,17 @@ public class ZigbeeOutboundRelay(
                 "Sending ZCL command {@ClusterId}/{@CommandId} to {@ExternalId}",
                 request.ClusterId,
                 request.CommandId,
-                externalId
+                device.ExternalId
             );
-            await coordinator.SendCommandAsync(request, token);
+            var confirm = await coordinator.SendCommandAsync(request, token);
+            if (confirm.ConfirmStatus != SuccessConfirmStatus)
+                logger.LogWarning(
+                    "Zigbee command {@ClusterId}/{@CommandId} to {@ExternalId} failed with APS confirm status {@ConfirmStatus}",
+                    request.ClusterId,
+                    request.CommandId,
+                    device.ExternalId,
+                    confirm.ConfirmStatus
+                );
         }
     }
 }

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Core.Models;
@@ -6,9 +7,12 @@ using Haus.Core.Models.ExternalMessages;
 using Haus.Mqtt.Client;
 using Haus.Zigbee.Host.Zigbee.Mappers.ToHaus;
 using Haus.Zigbee.Host.Zigbee.Mappers.ToZigbee;
+using Haus.Zigbee.Models;
 using Haus.Zigbee.Serial.Frames;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
+using Polly;
+using Polly.Retry;
 
 namespace Haus.Zigbee.Host.Zigbee.Services;
 
@@ -102,7 +106,7 @@ public class ZigbeeOutboundRelay(
                 request.CommandId,
                 device.ExternalId
             );
-            var confirm = await coordinator.SendCommandAsync(request, token);
+            var confirm = await SendWithApsAckRetryAsync(request, device.ExternalId, token);
             if (confirm.ConfirmStatus != SuccessConfirmStatus)
                 logger.LogWarning(
                     "Zigbee command {@ClusterId}/{@CommandId} to {@ExternalId} failed with APS confirm status {@ConfirmStatus}",
@@ -112,5 +116,51 @@ public class ZigbeeOutboundRelay(
                     confirm.ConfirmStatus
                 );
         }
+    }
+
+    // Mirrors zigbee-herdsman's deCONZ adapter: on a failed confirm, retry exactly once at the
+    // same NWK address (no re-resolve, no mode switch) escalated to an APS-ACK request, then
+    // surface whatever the last attempt reported. `token` already bounds "time remains" -- if it's
+    // been canceled the pipeline won't retry. The retry flag is captured per call, not shared
+    // state, since concurrent lighting commands each build and run their own pipeline instance;
+    // that construction is negligible next to the tens-of-seconds a real Zigbee round trip takes.
+    private async Task<ApsDataConfirm> SendWithApsAckRetryAsync(
+        ZigbeeCommandRequest request,
+        string externalId,
+        CancellationToken token
+    )
+    {
+        var isRetryAttempt = false;
+        var pipeline = new ResiliencePipelineBuilder<ApsDataConfirm>()
+            .AddRetry(
+                new RetryStrategyOptions<ApsDataConfirm>
+                {
+                    MaxRetryAttempts = 1,
+                    Delay = TimeSpan.Zero,
+                    ShouldHandle = new PredicateBuilder<ApsDataConfirm>().HandleResult(confirm =>
+                        confirm.ConfirmStatus != SuccessConfirmStatus
+                    ),
+                    OnRetry = args =>
+                    {
+                        isRetryAttempt = true;
+                        logger.LogWarning(
+                            "Retrying Zigbee command {@ClusterId}/{@CommandId} to {@ExternalId} with APS-ACK after confirm status {@ConfirmStatus}",
+                            request.ClusterId,
+                            request.CommandId,
+                            externalId,
+                            args.Outcome.Result?.ConfirmStatus
+                        );
+                        return default;
+                    },
+                }
+            )
+            .Build();
+
+        return await pipeline.ExecuteAsync(
+            ct => new ValueTask<ApsDataConfirm>(
+                coordinator.SendCommandAsync(request with { RequestApsAck = isRetryAttempt }, ct)
+            ),
+            token
+        );
     }
 }

--- a/src/Haus.Zigbee/Coordinator/CommandSender.cs
+++ b/src/Haus.Zigbee/Coordinator/CommandSender.cs
@@ -12,6 +12,10 @@ namespace Haus.Zigbee.Coordinator;
 public class CommandSender(ApsSender sender)
 {
     private const byte NoApsAckRequested = 0x00;
+
+    // deCONZ APS-DATA.request TxOptions bit 2: request an APS-layer acknowledgment (a real
+    // delivery receipt from the destination) rather than just the usual MAC-layer confirm.
+    private const byte ApsAckRequested = 0x04;
     private const byte UnlimitedRadius = 0x00;
 
     private readonly ApsSender _sender = sender;
@@ -36,7 +40,7 @@ public class CommandSender(ApsSender sender)
             ClusterId: request.ClusterId,
             SourceEndpoint: request.SourceEndpoint,
             AsduPayload: asdu,
-            TxOptions: NoApsAckRequested,
+            TxOptions: request.RequestApsAck ? ApsAckRequested : NoApsAckRequested,
             Radius: UnlimitedRadius
         );
         return _sender.SendAsync(apsRequest, token);

--- a/src/Haus.Zigbee/Models/ZigbeeCommandRequest.cs
+++ b/src/Haus.Zigbee/Models/ZigbeeCommandRequest.cs
@@ -9,5 +9,6 @@ public record ZigbeeCommandRequest(
     ushort ClusterId,
     byte CommandId,
     byte[] Payload,
-    bool DisableDefaultResponse
+    bool DisableDefaultResponse,
+    bool RequestApsAck = false
 );

--- a/tests/Haus.Zigbee.Host.Tests/Support/CapturingLoggerFactory.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/CapturingLoggerFactory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Haus.Zigbee.Host.Tests.Support;
+
+// Each CreateLogger call gets its own logger instance tagged with its own category, all writing
+// into one shared, lock-protected list -- so entries stay attributed to whichever type actually
+// logged them, even though several types can share this one factory.
+public class CapturingLoggerFactory : ILoggerFactory
+{
+    private readonly List<LogEntry> _entries = [];
+
+    public IReadOnlyList<LogEntry> Entries
+    {
+        get
+        {
+            lock (_entries)
+                return _entries.ToList();
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName) => new CategoryLogger(categoryName, _entries);
+
+    public void AddProvider(ILoggerProvider provider) { }
+
+    public void Dispose() { }
+
+    private class CategoryLogger(string category, List<LogEntry> entries) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            lock (entries)
+                entries.Add(new LogEntry(category, logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose() { }
+    }
+}
+
+public record LogEntry(string Category, LogLevel Level, string Message, Exception? Exception);

--- a/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
@@ -15,6 +15,10 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public IReadOnlyList<ZigbeeDevice> DevicesToReturn { get; set; } = [];
     public ApsDataConfirm ConfirmToReturn { get; set; } =
         new(0, 0, 0, DeconzAddressMode.Nwk, 0, null, 0, 0, ConfirmStatus: 0);
+
+    // Lets a test script successive confirms across retried sends (e.g. fail then succeed);
+    // SendCommandAsync falls back to ConfirmToReturn once this is exhausted.
+    public Queue<ApsDataConfirm> ConfirmSequence { get; } = new();
     public ZigbeeDeviceInfo? DeviceInfoToReturn { get; set; }
 
     public bool IsConnected { get; set; }
@@ -61,7 +65,8 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public Task<ApsDataConfirm> SendCommandAsync(ZigbeeCommandRequest request, CancellationToken token)
     {
         SentCommands.Add(request);
-        return Task.FromResult(ConfirmToReturn);
+        var confirm = ConfirmSequence.Count > 0 ? ConfirmSequence.Dequeue() : ConfirmToReturn;
+        return Task.FromResult(confirm);
     }
 
     public void RaiseDeviceJoined(ZigbeeDeviceJoined joined)

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
@@ -11,7 +11,9 @@ using Haus.Zigbee.Host.Tests.Support;
 using Haus.Zigbee.Host.Zigbee;
 using Haus.Zigbee.Host.Zigbee.Services;
 using Haus.Zigbee.Models;
+using Haus.Zigbee.Serial.Frames;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Haus.Zigbee.Host.Tests.Zigbee.Services;
@@ -22,13 +24,16 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
     private FakeZigbeeCoordinator? _coordinator;
     private DeviceAddressRegistry? _addressRegistry;
     private ZigbeeOutboundRelay? _relay;
+    private CapturingLoggerFactory? _loggerFactory;
 
     public async Task InitializeAsync()
     {
         _coordinator = new FakeZigbeeCoordinator();
+        _loggerFactory = new CapturingLoggerFactory();
         var provider = ServiceProviderFactory.Create(
             mqttFactory: new FakeMqttClientFactory(),
-            zigbeeCoordinator: _coordinator
+            zigbeeCoordinator: _coordinator,
+            configureServices: services => services.AddSingleton<ILoggerFactory>(_loggerFactory)
         );
         var mqttClientFactory = provider.GetRequiredService<IHausMqttClientFactory>();
         _hausMqttClient = await mqttClientFactory.CreateClient();
@@ -82,10 +87,14 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleCommandAsync_LightingCommand_ResolvesAddressAndSendsCommands()
+    public async Task HandleCommandAsync_LightingCommand_ResolvesNetworkAddressAndSendsCommands()
     {
-        var address = new IeeeAddress(1);
-        var device = new DeviceModel { ExternalId = ExternalIdConverter.ToExternalId(address) };
+        const ushort networkAddress = 0x1234;
+        var device = new DeviceModel
+        {
+            ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
+            NetworkAddress = networkAddress,
+        };
         var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
             .AsHausCommand()
             .ToMqttMessage("haus/commands");
@@ -93,12 +102,20 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
         await _relay!.HandleCommandAsync(message, CancellationToken.None);
 
         Assert.NotEmpty(_coordinator!.SentCommands);
+        Assert.All(
+            _coordinator.SentCommands,
+            request =>
+            {
+                Assert.Equal(DeconzAddressMode.Nwk, request.Destination.Mode);
+                Assert.Equal(networkAddress, request.Destination.ShortAddress);
+            }
+        );
     }
 
     [Fact]
-    public async Task HandleCommandAsync_LightingCommandWithUnresolvableExternalId_SendsNothing()
+    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddress_SendsNothing()
     {
-        var device = new DeviceModel { ExternalId = "not-an-address" };
+        var device = new DeviceModel { ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)) };
         var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
             .AsHausCommand()
             .ToMqttMessage("haus/commands");
@@ -106,5 +123,37 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
         await _relay!.HandleCommandAsync(message, CancellationToken.None);
 
         Assert.Empty(_coordinator!.SentCommands);
+    }
+
+    [Fact]
+    public async Task HandleCommandAsync_LightingCommandWithFailedConfirmStatus_LogsWarningWithoutThrowing()
+    {
+        _coordinator!.ConfirmToReturn = new ApsDataConfirm(
+            0,
+            0,
+            0,
+            DeconzAddressMode.Nwk,
+            0x1234,
+            null,
+            1,
+            1,
+            ConfirmStatus: 0xAD
+        );
+        var device = new DeviceModel
+        {
+            ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
+            NetworkAddress = 0x1234,
+        };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+
+        await _relay!.HandleCommandAsync(message, CancellationToken.None);
+
+        Assert.NotEmpty(_coordinator.SentCommands);
+        Assert.Contains(
+            _loggerFactory!.Entries,
+            entry => entry.Level == LogLevel.Warning && entry.Message.Contains("confirm status")
+        );
     }
 }

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
@@ -126,34 +126,62 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleCommandAsync_LightingCommandWithFailedConfirmStatus_LogsWarningWithoutThrowing()
+    public async Task HandleCommandAsync_LightingCommandWithFailedConfirmThenSuccessOnRetry_RetriesOnceWithApsAckAndDoesNotLogFailure()
     {
-        _coordinator!.ConfirmToReturn = new ApsDataConfirm(
-            0,
-            0,
-            0,
-            DeconzAddressMode.Nwk,
-            0x1234,
-            null,
-            1,
-            1,
-            ConfirmStatus: 0xAD
-        );
+        _coordinator!.ConfirmSequence.Enqueue(FailedConfirm());
+        _coordinator.ConfirmSequence.Enqueue(SuccessfulConfirm());
         var device = new DeviceModel
         {
             ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
             NetworkAddress = 0x1234,
         };
-        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.Off))
             .AsHausCommand()
             .ToMqttMessage("haus/commands");
 
         await _relay!.HandleCommandAsync(message, CancellationToken.None);
 
-        Assert.NotEmpty(_coordinator.SentCommands);
-        Assert.Contains(
+        Assert.Equal(2, _coordinator.SentCommands.Count);
+        Assert.False(_coordinator.SentCommands[0].RequestApsAck);
+        Assert.True(_coordinator.SentCommands[1].RequestApsAck);
+        Assert.Equal(_coordinator.SentCommands[0].Destination, _coordinator.SentCommands[1].Destination);
+        Assert.DoesNotContain(
             _loggerFactory!.Entries,
-            entry => entry.Level == LogLevel.Warning && entry.Message.Contains("confirm status")
+            entry => entry.Level == LogLevel.Warning && entry.Message.Contains("failed with APS confirm status")
         );
+    }
+
+    [Fact]
+    public async Task HandleCommandAsync_LightingCommandWithConfirmFailingTwice_RetriesExactlyOnceThenLogsFailure()
+    {
+        _coordinator!.ConfirmToReturn = FailedConfirm();
+        var device = new DeviceModel
+        {
+            ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
+            NetworkAddress = 0x1234,
+        };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.Off))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+
+        await _relay!.HandleCommandAsync(message, CancellationToken.None);
+
+        Assert.Equal(2, _coordinator.SentCommands.Count);
+        Assert.False(_coordinator.SentCommands[0].RequestApsAck);
+        Assert.True(_coordinator.SentCommands[1].RequestApsAck);
+        Assert.Single(
+            _loggerFactory!.Entries,
+            entry => entry.Level == LogLevel.Warning && entry.Message.Contains("failed with APS confirm status")
+        );
+    }
+
+    private static ApsDataConfirm FailedConfirm()
+    {
+        return new ApsDataConfirm(0, 0, 0, DeconzAddressMode.Nwk, 0x1234, null, 1, 1, ConfirmStatus: 0xAD);
+    }
+
+    private static ApsDataConfirm SuccessfulConfirm()
+    {
+        return new ApsDataConfirm(0, 0, 0, DeconzAddressMode.Nwk, 0x1234, null, 1, 1, ConfirmStatus: 0x00);
     }
 }

--- a/tests/Haus.Zigbee.Tests/Coordinator/CommandSenderTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/CommandSenderTests.cs
@@ -79,6 +79,48 @@ public class CommandSenderTests
     }
 
     [Fact]
+    public void WhenRequestingApsAckThenTheApsRequestSetsTheApsAckTxOptionsBit()
+    {
+        var request = new ZigbeeCommandRequest(
+            Destination: ApsDestination.Nwk(0x1234, 0x01),
+            SourceEndpoint: 0x01,
+            ProfileId: 0x0104,
+            ClusterId: 0x0006,
+            CommandId: 0x01,
+            Payload: new byte[] { 0xaa, 0xbb },
+            DisableDefaultResponse: true,
+            RequestApsAck: true
+        );
+
+        var timeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        _ = _commandSender.SendCommandAsync(request, timeout.Token);
+
+        var expectedAsdu = ZclCommandFactory.Encode(
+            new ZclCommand(
+                TransactionSequenceNumber: 0,
+                CommandId: 0x01,
+                Payload: new byte[] { 0xaa, 0xbb },
+                DisableDefaultResponse: true
+            )
+        );
+        var expectedFrame = new ApsDataRequestFrame(
+            SequenceNumber: 0,
+            RequestId: 0,
+            Destination: ApsDestination.Nwk(0x1234, 0x01),
+            ProfileId: 0x0104,
+            ClusterId: 0x0006,
+            SourceEndpoint: 0x01,
+            AsduPayload: expectedAsdu,
+            TxOptions: 0x04,
+            Radius: 0x00
+        );
+        Assert.Equal(
+            DeconzFrames.Framed(ApsDataRequestFrameCodec.Encode(expectedFrame)),
+            _senderTransport.WrittenBytes
+        );
+    }
+
+    [Fact]
     public async Task WhenTheCoordinatorConfirmsDeliveryThenThatConfirmIsReturnedToTheCaller()
     {
         _senderTransport.QueueResponse(DeconzFrames.Framed(DeconzAck(sequenceNumber: 0)));


### PR DESCRIPTION
## Depends on #62

This PR is stacked on `polly/device-network-address-field` (PR #62, not yet merged), which adds the typed `Device.NetworkAddress` field this fix relies on. **Base should be retargeted to `main` once #62 lands.**

## Summary

Investigation compared HAUS's outbound Zigbee command path against zigbee-herdsman's deCONZ adapter (used by zigbee2mqtt, which worked reliably against the same ConBee/RaspBee firmware) and found two bugs in `ZigbeeOutboundRelay`, both fixed here:

1. **IEEE-mode addressing instead of NWK-mode.** `HandleLightingAsync` resolved destinations via `ApsDestination.Ieee(...)` from `Device.ExternalId`, while every other outbound path in the codebase (e.g. `DeviceInterview.cs`) and zigbee-herdsman's deCONZ adapter use NWK-mode exclusively — with no IEEE fallback anywhere in herdsman's own code. Herdsman's bug history (Koenkk/zigbee-herdsman#576, #1194) shows that when NWK addresses go stale, the fix is tighter reactive address-table maintenance, never falling back to IEEE addressing.
2. **Discarded `ApsDataConfirm`.** The per-request Zigbee/APS delivery outcome returned by `coordinator.SendCommandAsync` was never checked or logged, so a command always looked like it succeeded even if the device never received it.

**Update:** the retry-escalation gap originally called out as a follow-up below is now implemented (see "Retry escalation" section).

## Changes

- `ZigbeeOutboundRelay.HandleLightingAsync` now resolves the destination from `Device.NetworkAddress` (NWK-mode) instead of parsing `ExternalId` into an IEEE address. If `NetworkAddress` is null (not yet known), it logs a warning and skips the send rather than crashing or guessing.
- The `ApsDataConfirm` returned from sending is captured; a non-success `ConfirmStatus` (per Zigbee APS spec, `0x00` is `APS_SUCCESS`) is logged as a warning with cluster/command/device/status detail instead of being silently swallowed.
- Added/updated tests in `ZigbeeOutboundRelayTests`:
  - NWK-mode addressing is used (asserts `Destination.Mode == Nwk` and the resolved short address).
  - A device with no known `NetworkAddress` sends nothing (replaces the old "unresolvable ExternalId" case, which no longer applies since ExternalId is no longer used for address resolution).
  - Retry + failure-surfacing cases (see below).
- Added a small `CapturingLoggerFactory` test double to `Haus.Zigbee.Host.Tests/Support` (mirroring the existing one in `Haus.Zigbee.Tests`) to assert on log output.

## Retry escalation (APS-ACK, via Polly)

Mirrors zigbee-herdsman's deCONZ adapter (`frameParser.ts:190-227`): on a non-success `ApsDataConfirm.ConfirmStatus`, retry **exactly once** at the same NWK address (no re-resolve, no mode switch) escalated to an APS-ACK request; if that also fails, surface/log the failure as before rather than retrying again.

- Added `RequestApsAck` to `ZigbeeCommandRequest` (defaults `false`), threaded through `CommandSender` into the APS request's `TxOptions` (bit 2 — deCONZ's APS-ACK-requested flag; there was no existing knob for this, so this is the minimal plumbing added).
- `ZigbeeOutboundRelay` wraps each send in a Polly v8 `ResiliencePipeline<ApsDataConfirm>` (`ResiliencePipelineBuilder<T>` + `AddRetry`, **not** the legacy `Policy` static API) configured for a single, no-delay retry (`MaxRetryAttempts = 1`, `Delay = TimeSpan.Zero`) keyed on a `ShouldHandle` predicate matching non-success `ConfirmStatus`. `OnRetry` flips a per-call flag that makes the retried send set `RequestApsAck: true`; the original send stays `false`. The existing failure-logging in `HandleLightingAsync` is unchanged — it now just observes the pipeline's final result, so it only fires when the retry also fails.
- `Polly` 8.7.0 (pinned to match the version already used by `Haus.Mqtt.Client`/`Haus.Testing.Support`) was added as a `PackageReference` to `Haus.Zigbee.Host` only, since that's the only project needing it.
- New tests:
  - `CommandSenderTests`: `RequestApsAck: true` sets the APS-ACK `TxOptions` bit on the outgoing frame.
  - `ZigbeeOutboundRelayTests`: first attempt fails → exactly one retry with APS-ACK at the same destination → if the retry succeeds, no failure is logged; if the retry also fails, exactly one failure is logged (not retried again).
- `FakeZigbeeCoordinator` gained a `ConfirmSequence` queue so tests can script different confirms across the original send and its retry.

## Testing

- `dotnet build` — succeeds (pre-existing unrelated failure: `Haus.Acceptance.Tests`' Playwright browser install fails in this sandbox with no network/sudo access — unrelated to this change).
- `dotnet test tests/Haus.Zigbee.Host.Tests` — 84/84 passing.
- `dotnet test tests/Haus.Zigbee.Tests` — 234/234 passing.
- `dotnet test tests/Haus.Web.Host.Tests` — 3 pre-existing failures in `ApplicationApiTests` (GitHub releases API, requires `GITHUB_TOKEN`/network not available in this sandbox), unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0185fxz2KFZNbThosjrjAtFY