### PR TITLE
chore(deps): bump .NET SDK to latest stable (10.0.400)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.400",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
## Summary

Routine dependency-maintenance audit across all three categories: NuGet packages, GitHub Actions, and the .NET SDK. Only the SDK needed a bump — the other two categories were already at latest stable.

## What changed

- **.NET SDK**: `10.0.100` → `10.0.400` in `global.json` (latest stable per [official .NET 10 release notes](https://github.com/dotnet/core/blob/main/release-notes/10.0/releases.json) — released 2026-08-11, ships the 10.0.11 runtime security patch).

## What was checked but needed no change

- **NuGet packages**: `dotnet list Haus.slnx package --outdated` reports zero outdated packages across every project in the solution — all already at latest stable. (Matches the recent #55 audit.)
- **GitHub Actions**: every `uses:` pin in `main.yaml`, `release.yaml`, and `.github/actions/setup-machine` (`actions/checkout@v7`, `actions/setup-dotnet@v6`, `actions/upload-artifact@v7`, `taiki-e/install-action@v2`, `softprops/action-gh-release@v3`) already resolves (verified by commit SHA) to that action's current latest stable release — nothing to bump.

## Verification

Local sandbox note: this dev container lacks passwordless `sudo`, which blocks the Acceptance.Tests project's `playwright install --with-deps` post-build step (confirmed pre-existing on `main` before any changes — not caused by this PR; real CI runners have full sudo). Installed a standalone SDK 10.0.400 + `wasm-tools` workload locally to validate against the new pinned version, working around the sudo gap by running `dotnet test tests/Haus.Acceptance.Tests --no-build` (build artifacts were already produced) instead of the Makefile's `--no-restore` variant, so the acceptance suite itself still ran for real against the full docker-compose stack.

- ✅ `dotnet build` — succeeds under SDK 10.0.400 (only the known pre-existing sandbox-sudo Playwright step fails, confirmed identical on `main`)
- ✅ `make test-unit` — 938/938 passed
- ✅ Acceptance suite — 7/7 passed, run against the full `docker-compose.local.yml` stack with real Auth0 login
- ✅ Conventional Commits `commit-msg` hook passed

CI (GitHub Actions `ubuntu-26.04` runners, which have full sudo) will additionally exercise the real `make build` / `make test-unit` / `make test-acceptance` targets end-to-end without the local workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)