### PR TITLE
fix(site-host): correct device detail page UI issues

### DIFF
--- a/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
+++ b/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
@@ -47,23 +47,32 @@
                   InputId="roomId"
                   Value="Device.RoomId"/>
 
-    @if (Device.Metadata.Length > 0)
-    {
-        <MudPaper Class="pa-4">
-            <MudText Typo="Typo.h4">Metadata</MudText>
-            <EditableMetadataListView Items="Device.Metadata"/>
-        </MudPaper>
-    }
-
     @if (Device.DeviceType == DeviceType.Light)
     {
         <LightingView Lighting="Device.Lighting ?? new LightingModel()"
+                      Title="Lighting"
                       OnLightingChanged="HandleLightingChanged"/>
+    }
+
+    @if (Device.Metadata.Length > 0)
+    {
+        <MudExpansionPanels>
+            <MudExpansionPanel @bind-Expanded="_metadataExpanded">
+                <TitleContent>
+                    <MudText Typo="Typo.h6">Metadata</MudText>
+                </TitleContent>
+                <ChildContent>
+                    <EditableMetadataListView Items="Device.Metadata"/>
+                </ChildContent>
+            </MudExpansionPanel>
+        </MudExpansionPanels>
     }
 </MudPaper>
 
 @code {
     [Parameter] public required DeviceModel Device { get; set; }
+
+    private bool _metadataExpanded;
 
     private async Task HandleDeleteClicked()
     {

--- a/src/Haus.Site.Host/Rooms/Detail/RoomDetailView.razor
+++ b/src/Haus.Site.Host/Rooms/Detail/RoomDetailView.razor
@@ -29,6 +29,7 @@
         </MudItem>
         <MudItem xs="12">
             <LightingView Lighting="Room.Lighting"
+                          Title="Room Lighting"
                           OnLightingChanged="HandleLightingChanged"/>
         </MudItem>
     </MudGrid>

--- a/src/Haus.Site.Host/Shared/Lighting/LightingView.razor
+++ b/src/Haus.Site.Host/Shared/Lighting/LightingView.razor
@@ -11,7 +11,7 @@ else
 {
     <MudGrid>
         <MudItem>
-            <MudText Typo="Typo.h5">Room Lighting</MudText>
+            <MudText Typo="Typo.h5">@Title</MudText>
         </MudItem>
         <MudItem xs="12">
             <MudSwitch T="bool"
@@ -106,6 +106,8 @@ else
     private IDisposable? _subscription;
 
     [Parameter] public bool Disabled { get; set; }
+
+    [Parameter] public string Title { get; set; } = "Room Lighting";
 
     [Parameter] public LightingModel? Lighting { get; set; }
 

--- a/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -127,6 +128,77 @@ public class DeviceDetailViewTests : HausSiteTestContext
         // "mud-icon-button" class, so the delete button needs its own selector to stay
         // uniquely identifiable (regression test for that collision).
         Assert.Single(page.FindAll(".delete-device-button"));
+    }
+
+    [Fact]
+    public void WhenDeviceTypeIsLightThenShowsLightingViewTitledLighting()
+    {
+        var device = HausModelFactory.DeviceModel() with { DeviceType = DeviceType.Light };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        Assert.Equal("Lighting", page.FindByComponent<LightingView>().Instance.Title);
+    }
+
+    [Fact]
+    public void WhenRenderedThenSectionsAreOrderedDeviceDetailsThenLightingThenMetadata()
+    {
+        var device = HausModelFactory.DeviceModel() with
+        {
+            DeviceType = DeviceType.Light,
+            Metadata = [HausModelFactory.MetadataModel()],
+        };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        var markup = page.Markup;
+        var deviceDetailsIndex = markup.IndexOf("id=\"roomId\"", StringComparison.Ordinal);
+        var lightingIndex = markup.IndexOf(">Lighting<", StringComparison.Ordinal);
+        var metadataIndex = markup.IndexOf("Metadata", StringComparison.Ordinal);
+
+        Assert.True(deviceDetailsIndex >= 0);
+        Assert.True(lightingIndex >= 0);
+        Assert.True(metadataIndex >= 0);
+        Assert.True(deviceDetailsIndex < lightingIndex, "device details should render before the lighting section");
+        Assert.True(lightingIndex < metadataIndex, "the lighting section should render before the metadata section");
+    }
+
+    [Fact]
+    public void WhenRenderedThenMetadataSectionIsCollapsedByDefault()
+    {
+        var device = HausModelFactory.DeviceModel() with { Metadata = [HausModelFactory.MetadataModel()] };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        Assert.False(page.FindByComponent<MudExpansionPanel>().Instance.Expanded);
+    }
+
+    [Fact]
+    public void WhenMetadataPanelHeaderIsClickedThenMetadataSectionExpands()
+    {
+        var device = HausModelFactory.DeviceModel() with { Metadata = [HausModelFactory.MetadataModel()] };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        var panel = page.FindByComponent<MudExpansionPanel>();
+        panel.Find(".mud-expand-panel-header").Click();
+
+        Eventually.Assert(() =>
+        {
+            Assert.True(panel.Instance.Expanded);
+        });
     }
 
     [Fact]

--- a/tests/Haus.Site.Host.Tests/Shared/Lighting/LightingViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Shared/Lighting/LightingViewTests.cs
@@ -21,6 +21,24 @@ public class LightingViewTests : HausSiteTestContext
     }
 
     [Fact]
+    public void WhenRenderedWithoutTitleThenDefaultsToRoomLighting()
+    {
+        var lighting = HausModelFactory.LightingModel();
+        var view = RenderLighting(lighting);
+
+        Assert.NotNull(view.FindByComponent<MudText>(opts => opts.WithText("Room Lighting")));
+    }
+
+    [Fact]
+    public void WhenRenderedWithTitleThenShowsGivenTitle()
+    {
+        var lighting = HausModelFactory.LightingModel();
+        var view = RenderLighting(lighting, title: "Lighting");
+
+        Assert.NotNull(view.FindByComponent<MudText>(opts => opts.WithText("Lighting")));
+    }
+
+    [Fact]
     public void WhenRenderedDisabledThenAllInputsAreDisabled()
     {
         var lighting = HausModelFactory.LightingModel() with
@@ -220,7 +238,8 @@ public class LightingViewTests : HausSiteTestContext
     private IRenderedComponent<LightingView> RenderLighting(
         LightingModel? lighting,
         Action<LightingModel>? onChanged = null,
-        bool disabled = false
+        bool disabled = false,
+        string? title = null
     )
     {
         return Context.Render<LightingView>(opts =>
@@ -230,6 +249,10 @@ public class LightingViewTests : HausSiteTestContext
             if (onChanged != null)
             {
                 opts.Add(o => o.OnLightingChanged, onChanged);
+            }
+            if (title != null)
+            {
+                opts.Add(o => o.Title, title);
             }
         });
     }


### PR DESCRIPTION
## Summary
- `LightingView` now takes a `Title` parameter (default `"Room Lighting"`) instead of hardcoding "Room Lighting" — `RoomDetailView` passes `"Room Lighting"`, `DeviceDetailView` passes `"Lighting"` since it controls a single device, not a room.
- `DeviceDetailView` sections are now ordered: device details → lighting (light devices only) → metadata.
- The metadata section is now a collapsible `MudExpansionPanel` (collapsed by default) instead of an always-expanded `MudPaper`, matching existing usage elsewhere in the codebase (`ZigbeeDeviceView`, `EventView`, `DiagnosticsMessageView`).

Refs #9

## Test plan
- [x] Added bUnit tests for `LightingView`'s default/custom `Title` rendering
- [x] Added bUnit tests for `DeviceDetailView` section order and the metadata panel's collapsed/expanded behavior
- [x] `dotnet test tests/Haus.Site.Host.Tests` — 155/155 passing
- [x] `dotnet build` — clean except for a pre-existing, unrelated Playwright browser-install failure in `Haus.Acceptance.Tests` (sandbox has no sudo/terminal access; reproduces identically on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)