### PR TITLE
fix(zigbee): backfill NetworkAddress and surface dropped lighting commands

### DIFF
--- a/src/Haus.Core.Models/Zigbee/Events/ZigbeeCommandDroppedEvent.cs
+++ b/src/Haus.Core.Models/Zigbee/Events/ZigbeeCommandDroppedEvent.cs
@@ -1,0 +1,14 @@
+using Haus.Core.Models.Common;
+using Haus.Core.Models.ExternalMessages;
+
+namespace Haus.Core.Models.Zigbee.Events;
+
+public record ZigbeeCommandDroppedEvent(string ExternalId, string Reason) : IHausEventCreator<ZigbeeCommandDroppedEvent>
+{
+    public const string Type = "zigbee_command_dropped";
+
+    public HausEvent<ZigbeeCommandDroppedEvent> AsHausEvent()
+    {
+        return new(Type, this);
+    }
+}

--- a/src/Haus.Core/Common/Commands/InitializeCommand.cs
+++ b/src/Haus.Core/Common/Commands/InitializeCommand.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Core.Common.Storage.Commands;
+using Haus.Core.Devices.Commands;
 using Haus.Core.Discovery.Commands;
 using Haus.Cqrs;
 using Haus.Cqrs.Commands;
@@ -14,6 +15,9 @@ internal class InitializeCommandHandler(IHausBus hausBus) : ICommandHandler<Init
     public async Task Handle(InitializeCommand request, CancellationToken cancellationToken)
     {
         await hausBus.ExecuteCommandAsync(new InitializeDatabaseCommand(), cancellationToken).ConfigureAwait(false);
+        await hausBus
+            .ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand(), cancellationToken)
+            .ConfigureAwait(false);
         await Task.WhenAll(
                 hausBus.ExecuteCommandAsync(new InitializeDiscoveryCommand(), cancellationToken),
                 hausBus.ExecuteCommandAsync(new SyncDiscoveryCommand(), cancellationToken)

--- a/src/Haus.Core/Common/Events/RoutableEventFactory.cs
+++ b/src/Haus.Core/Common/Events/RoutableEventFactory.cs
@@ -31,6 +31,7 @@ public class RoutableEventFactory : IRoutableEventFactory
             ZigbeeAttributeReportReceivedEvent.Type => CreateRoutableEvent<ZigbeeAttributeReportReceivedEvent>(bytes),
             ZigbeeCommandSentEvent.Type => CreateRoutableEvent<ZigbeeCommandSentEvent>(bytes),
             ZigbeeTransportErrorEvent.Type => CreateRoutableEvent<ZigbeeTransportErrorEvent>(bytes),
+            ZigbeeCommandDroppedEvent.Type => CreateRoutableEvent<ZigbeeCommandDroppedEvent>(bytes),
             _ => null,
         };
     }

--- a/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
+++ b/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
@@ -24,7 +24,6 @@ internal class BackfillDeviceNetworkAddressesCommandHandler(HausDbContext contex
             .ToArrayAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var backfilled = false;
         foreach (var device in devicesMissingNetworkAddress)
         {
             var legacyValue = device.Metadata.FirstOrDefault(m => m.Key == LegacyNetworkAddressMetadataKey)?.Value;
@@ -32,10 +31,8 @@ internal class BackfillDeviceNetworkAddressesCommandHandler(HausDbContext contex
                 continue;
 
             device.NetworkAddress = networkAddress;
-            backfilled = true;
         }
 
-        if (backfilled)
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
+++ b/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
@@ -24,15 +24,19 @@ internal class BackfillDeviceNetworkAddressesCommandHandler(HausDbContext contex
             .ToArrayAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        foreach (var device in devicesMissingNetworkAddress)
-        {
-            var legacyValue = device.Metadata.FirstOrDefault(m => m.Key == LegacyNetworkAddressMetadataKey)?.Value;
-            if (legacyValue == null || !ushort.TryParse(legacyValue, out var networkAddress))
-                continue;
+        var devicesToBackfill = devicesMissingNetworkAddress
+            .Select(d => (Device: d, NetworkAddress: ParseLegacyNetworkAddress(d)))
+            .Where(d => d.NetworkAddress != null);
 
+        foreach (var (device, networkAddress) in devicesToBackfill)
             device.NetworkAddress = networkAddress;
-        }
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ushort? ParseLegacyNetworkAddress(DeviceEntity device)
+    {
+        var legacyValue = device.Metadata.FirstOrDefault(m => m.Key == LegacyNetworkAddressMetadataKey)?.Value;
+        return legacyValue != null && ushort.TryParse(legacyValue, out var networkAddress) ? networkAddress : null;
     }
 }

--- a/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
+++ b/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common.Storage;
+using Haus.Core.Devices.Entities;
+using Haus.Cqrs.Commands;
+using Microsoft.EntityFrameworkCore;
+
+namespace Haus.Core.Devices.Commands;
+
+public record BackfillDeviceNetworkAddressesCommand : ICommand;
+
+// PR #62 promoted NetworkAddress to a typed column but never backfilled it, so every device that
+// was known before that migration has NetworkAddress == null even though its network address was
+// already captured in the legacy Metadata["network_address"] entry -- this reconciles the two on
+// every startup, which is what makes it safe to run repeatedly.
+internal class BackfillDeviceNetworkAddressesCommandHandler(HausDbContext context)
+    : ICommandHandler<BackfillDeviceNetworkAddressesCommand>
+{
+    private const string LegacyNetworkAddressMetadataKey = "network_address";
+
+    public async Task Handle(BackfillDeviceNetworkAddressesCommand request, CancellationToken cancellationToken)
+    {
+        var devicesMissingNetworkAddress = await context
+            .Set<DeviceEntity>()
+            .Include(d => d.Metadata)
+            .Where(d => d.NetworkAddress == null)
+            .ToArrayAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var backfilled = false;
+        foreach (var device in devicesMissingNetworkAddress)
+        {
+            var legacyValue = device.Metadata.FirstOrDefault(m => m.Key == LegacyNetworkAddressMetadataKey)?.Value;
+            if (legacyValue == null || !ushort.TryParse(legacyValue, out var networkAddress))
+                continue;
+
+            device.NetworkAddress = networkAddress;
+            backfilled = true;
+        }
+
+        if (backfilled)
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
+++ b/src/Haus.Core/Devices/Commands/BackfillDeviceNetworkAddressesCommand.cs
@@ -10,10 +10,6 @@ namespace Haus.Core.Devices.Commands;
 
 public record BackfillDeviceNetworkAddressesCommand : ICommand;
 
-// PR #62 promoted NetworkAddress to a typed column but never backfilled it, so every device that
-// was known before that migration has NetworkAddress == null even though its network address was
-// already captured in the legacy Metadata["network_address"] entry -- this reconciles the two on
-// every startup, which is what makes it safe to run repeatedly.
 internal class BackfillDeviceNetworkAddressesCommandHandler(HausDbContext context)
     : ICommandHandler<BackfillDeviceNetworkAddressesCommand>
 {

--- a/src/Haus.Core/Zigbee/Events/ZigbeeCommandDroppedEventHandler.cs
+++ b/src/Haus.Core/Zigbee/Events/ZigbeeCommandDroppedEventHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Core.Common;
+using Haus.Core.Common.Events;
+using Haus.Core.Models.Zigbee;
+using Haus.Core.Models.Zigbee.Events;
+using Haus.Core.Zigbee.State;
+using Haus.Cqrs.Events;
+
+namespace Haus.Core.Zigbee.Events;
+
+internal class ZigbeeCommandDroppedEventHandler(IZigbeeStore store, IClock clock)
+    : IEventHandler<RoutableEvent<ZigbeeCommandDroppedEvent>>
+{
+    public Task Handle(RoutableEvent<ZigbeeCommandDroppedEvent> notification, CancellationToken cancellationToken)
+    {
+        store.PublishNext(s =>
+            s.RecordActivity(new ZigbeeActivityEntryModel(notification.Type, clock.UtcNowOffset, notification.Payload))
+        );
+        return Task.CompletedTask;
+    }
+}

--- a/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
+++ b/src/Haus.Site.Host/Zigbee/Activity/ZigbeeActivityView.razor
@@ -39,6 +39,7 @@
         ZigbeeAttributeReportReceivedEvent.Type,
         ZigbeeCommandSentEvent.Type,
         ZigbeeTransportErrorEvent.Type,
+        ZigbeeCommandDroppedEvent.Type,
     ];
 
     private bool IsLoading { get; set; }

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Haus.Core.Models;
 using Haus.Core.Models.Devices.Events;
 using Haus.Core.Models.ExternalMessages;
+using Haus.Core.Models.Zigbee.Events;
 using Haus.Mqtt.Client;
 using Haus.Zigbee.Host.Zigbee.Mappers.ToHaus;
 using Haus.Zigbee.Host.Zigbee.Mappers.ToZigbee;
@@ -89,10 +90,10 @@ public class ZigbeeOutboundRelay(
         var device = command.Payload.Device;
         if (device.NetworkAddress is not { } networkAddress)
         {
-            logger.LogWarning(
-                "Cannot send a lighting command to {@ExternalId}: no known network address",
-                device.ExternalId
-            );
+            const string reason = "no known network address";
+            logger.LogWarning("Cannot send a lighting command to {@ExternalId}: {@Reason}", device.ExternalId, reason);
+            var hausMqttClient = await mqttClientFactory.CreateClient();
+            await hausMqttClient.PublishHausEventAsync(new ZigbeeCommandDroppedEvent(device.ExternalId, reason));
             return;
         }
 

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Core.Models;
+using Haus.Core.Models.Devices;
 using Haus.Core.Models.Devices.Events;
 using Haus.Core.Models.ExternalMessages;
 using Haus.Core.Models.Zigbee.Events;
@@ -90,10 +91,7 @@ public class ZigbeeOutboundRelay(
         var device = command.Payload.Device;
         if (device.NetworkAddress is not { } networkAddress)
         {
-            const string reason = "no known network address";
-            logger.LogWarning("Cannot send a lighting command to {@ExternalId}: {@Reason}", device.ExternalId, reason);
-            var hausMqttClient = await mqttClientFactory.CreateClient();
-            await hausMqttClient.PublishHausEventAsync(new ZigbeeCommandDroppedEvent(device.ExternalId, reason));
+            await HandleMissingNetworkAddressAsync(device);
             return;
         }
 
@@ -117,6 +115,14 @@ public class ZigbeeOutboundRelay(
                     confirm.ConfirmStatus
                 );
         }
+    }
+
+    private async Task HandleMissingNetworkAddressAsync(DeviceModel device)
+    {
+        const string reason = "no known network address";
+        logger.LogWarning("Cannot send a lighting command to {@ExternalId}: {@Reason}", device.ExternalId, reason);
+        var hausMqttClient = await mqttClientFactory.CreateClient();
+        await hausMqttClient.PublishHausEventAsync(new ZigbeeCommandDroppedEvent(device.ExternalId, reason));
     }
 
     // Mirrors zigbee-herdsman's deCONZ adapter: on a failed confirm, retry exactly once at the

--- a/tests/Haus.Core.Tests/Common/Events/RoutableEventFactoryTests.cs
+++ b/tests/Haus.Core.Tests/Common/Events/RoutableEventFactoryTests.cs
@@ -112,6 +112,18 @@ public class RoutableHausEventFactoryTest
     }
 
     [Fact]
+    public void WhenZigbeeCommandDroppedThenReturnsRoutableEventFromZigbeeCommandDropped()
+    {
+        var bytes = HausJsonSerializer.SerializeToBytes(
+            new ZigbeeCommandDroppedEvent("ext-1", "no known network address").AsHausEvent()
+        );
+
+        var routableEvent = _factory.Create(bytes);
+
+        Assert.IsType<RoutableEvent<ZigbeeCommandDroppedEvent>>(routableEvent);
+    }
+
+    [Fact]
     public void WhenBytesDoesNotRepresentAHausEventThenReturnsNull()
     {
         var bytes = HausJsonSerializer.SerializeToBytes("this is data");

--- a/tests/Haus.Core.Tests/Devices/Commands/BackfillDeviceNetworkAddressesCommandHandlerTests.cs
+++ b/tests/Haus.Core.Tests/Devices/Commands/BackfillDeviceNetworkAddressesCommandHandlerTests.cs
@@ -1,0 +1,65 @@
+using System.Threading.Tasks;
+using Haus.Core.Common.Storage;
+using Haus.Core.Devices.Commands;
+using Haus.Cqrs;
+using Haus.Testing.Support;
+using Xunit;
+
+namespace Haus.Core.Tests.Devices.Commands;
+
+public class BackfillDeviceNetworkAddressesCommandHandlerTests
+{
+    private readonly HausDbContext _context;
+    private readonly IHausBus _hausBus;
+
+    public BackfillDeviceNetworkAddressesCommandHandlerTests()
+    {
+        _context = HausDbContextFactory.Create();
+        _hausBus = HausBusFactory.Create(_context);
+    }
+
+    [Fact]
+    public async Task WhenDeviceHasLegacyNetworkAddressMetadataThenTypedNetworkAddressIsPopulated()
+    {
+        var device = _context.AddDevice(configure: d => d.AddOrUpdateMetadata("network_address", "4660"));
+
+        await _hausBus.ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand());
+
+        Assert.Equal((ushort)4660, device.NetworkAddress);
+    }
+
+    [Fact]
+    public async Task WhenBackfillRunsAgainThenNetworkAddressStaysCorrect()
+    {
+        var device = _context.AddDevice(configure: d => d.AddOrUpdateMetadata("network_address", "4660"));
+        await _hausBus.ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand());
+
+        await _hausBus.ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand());
+
+        Assert.Equal((ushort)4660, device.NetworkAddress);
+    }
+
+    [Fact]
+    public async Task WhenDeviceHasNoLegacyMetadataThenNetworkAddressRemainsNull()
+    {
+        var device = _context.AddDevice();
+
+        await _hausBus.ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand());
+
+        Assert.Null(device.NetworkAddress);
+    }
+
+    [Fact]
+    public async Task WhenDeviceAlreadyHasTypedNetworkAddressThenExistingValueIsNotOverwritten()
+    {
+        var device = _context.AddDevice(configure: d =>
+        {
+            d.NetworkAddress = 1;
+            d.AddOrUpdateMetadata("network_address", "4660");
+        });
+
+        await _hausBus.ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand());
+
+        Assert.Equal((ushort)1, device.NetworkAddress);
+    }
+}

--- a/tests/Haus.Core.Tests/Devices/Commands/BackfillDeviceNetworkAddressesCommandHandlerTests.cs
+++ b/tests/Haus.Core.Tests/Devices/Commands/BackfillDeviceNetworkAddressesCommandHandlerTests.cs
@@ -62,4 +62,14 @@ public class BackfillDeviceNetworkAddressesCommandHandlerTests
 
         Assert.Equal((ushort)1, device.NetworkAddress);
     }
+
+    [Fact]
+    public async Task WhenLegacyMetadataValueIsNotNumericThenNetworkAddressRemainsNull()
+    {
+        var device = _context.AddDevice(configure: d => d.AddOrUpdateMetadata("network_address", "not-a-number"));
+
+        await _hausBus.ExecuteCommandAsync(new BackfillDeviceNetworkAddressesCommand());
+
+        Assert.Null(device.NetworkAddress);
+    }
 }

--- a/tests/Haus.Core.Tests/Zigbee/Events/ZigbeeEventHandlersTests.cs
+++ b/tests/Haus.Core.Tests/Zigbee/Events/ZigbeeEventHandlersTests.cs
@@ -98,4 +98,14 @@ public class ZigbeeEventHandlersTests
 
         Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeTransportErrorEvent.Type);
     }
+
+    [Fact]
+    public async Task WhenCommandDroppedEventReceivedThenActivityIsRecorded()
+    {
+        await _hausBus.PublishAsync(
+            RoutableEvent.FromEvent(new ZigbeeCommandDroppedEvent("ext-1", "no known network address"))
+        );
+
+        Assert.Contains(_store.Current.RecentActivity, e => e.EventType == ZigbeeCommandDroppedEvent.Type);
+    }
 }

--- a/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Zigbee/Activity/ZigbeeActivityViewTests.cs
@@ -123,6 +123,32 @@ public class ZigbeeActivityViewTests : HausSiteTestContext
     }
 
     [Fact]
+    public async Task WhenCommandDroppedEventReceivedThenPrependsToActivityFeed()
+    {
+        await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>());
+        var view = RenderView<ZigbeeActivityView>();
+        Eventually.Assert(() =>
+        {
+            view.FindByComponent<MudText>(opts => opts.WithText("No recent zigbee activity"));
+        });
+
+        await _eventsSubscriber.SimulateAsync(
+            HausEventsEventNames.OnEvent,
+            new HausEvent<object>(
+                ZigbeeCommandDroppedEvent.Type,
+                new ZigbeeCommandDroppedEvent("ext-1", "no known network address")
+            )
+        );
+
+        Eventually.Assert(() =>
+        {
+            var entries = view.FindAllByComponent<ZigbeeActivityEntryView>().ToArray();
+            Assert.Single(entries);
+            Assert.Equal(ZigbeeCommandDroppedEvent.Type, entries[0].Instance.Entry?.EventType);
+        });
+    }
+
+    [Fact]
     public async Task WhenNonZigbeeEventReceivedThenIgnoresIt()
     {
         await HausApiHandler.SetupGetAsJson(ActivityUrl, new ListResult<ZigbeeActivityEntryModel>());

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
@@ -4,6 +4,7 @@ using Haus.Core.Models.Devices;
 using Haus.Core.Models.Devices.Events;
 using Haus.Core.Models.Discovery;
 using Haus.Core.Models.Lighting;
+using Haus.Core.Models.Zigbee.Events;
 using Haus.Mqtt.Client;
 using Haus.Testing.Support;
 using Haus.Testing.Support.Fakes;
@@ -123,6 +124,25 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
         await _relay!.HandleCommandAsync(message, CancellationToken.None);
 
         Assert.Empty(_coordinator!.SentCommands);
+    }
+
+    [Fact]
+    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddress_PublishesCommandDroppedEvent()
+    {
+        var externalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1));
+        var device = new DeviceModel { ExternalId = externalId };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+        ZigbeeCommandDroppedEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeCommandDroppedEvent>(
+            ZigbeeCommandDroppedEvent.Type,
+            e => published = e.Payload
+        );
+
+        await _relay!.HandleCommandAsync(message, CancellationToken.None);
+
+        Eventually.Assert(() => Assert.Equal(externalId, published?.ExternalId));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes a regression where lighting commands from both the room and device detail pages silently never reached real Zigbee hardware for any device that existed before #62/#63.

**Root cause:** #62 promoted `Device.NetworkAddress` from a string in the generic `Metadata` bag (key `"network_address"`) to a typed `ushort?` column, but never backfilled existing rows. #63 then added a guard in `ZigbeeOutboundRelay` that silently drops a lighting command (without calling the coordinator) when `NetworkAddress` is null, logging only a server-side warning nobody sees. Every device known before #62 therefore had its lighting commands dropped with zero visible signal.

## Changes

1. **Backfill** (`BackfillDeviceNetworkAddressesCommand`): a new idempotent CQRS command, run at startup right after `InitializeDatabaseCommand`, that populates `NetworkAddress` from the legacy `Metadata["network_address"]` entry for any device that's still missing it. It skips devices that already have a typed address (no clobbering), skips devices with no legacy entry, and safely no-ops on a non-numeric legacy value.

   Chose an EF-based command over a raw-SQL migration (`migrationBuilder.Sql`) because this repo's unit tests run entirely against EF Core's InMemory provider (no Sqlite in any test project) — a migration-only backfill would have been untestable at the unit level and only exercisable via a live SQLite acceptance run. The command mirrors the existing `ClearDatabaseCommand`/`InitializeDatabaseCommandHandler` shape in `Common/Storage/Commands`, so it fits the codebase's established CQRS conventions and is fully covered by `Haus.Core.Tests`.

2. **Diagnostics visibility** (`ZigbeeCommandDroppedEvent`): even after the backfill, a device that was never actually seen with a network address will still hit the guard. Previously that produced only a log warning. Now `ZigbeeOutboundRelay` also publishes a `ZigbeeCommandDroppedEvent`, wired through the same pipeline as the existing `ZigbeeCommandSentEvent`/`ZigbeeTransportErrorEvent` (event model → `RoutableEventFactory` → `ZigbeeStore`-recording event handler → `ZigbeeActivityView`'s live event allowlist), so the drop is now visible on the Zigbee diagnostics page instead of only a server log.

Closes #9.

## Test plan

- [x] `dotnet test tests/Haus.Core.Tests` — 266 passed
- [x] `dotnet test tests/Haus.Zigbee.Tests` — 234 passed
- [x] `dotnet test tests/Haus.Zigbee.Host.Tests` — 85 passed
- [x] `dotnet test tests/Haus.Web.Host.Tests` — 65 passed
- [x] `dotnet test tests/Haus.Site.Host.Tests` — 150 passed
- [x] Fresh-eyes review via an independent `craft-code-reviewer` pass — no blocking findings; added a regression test it flagged for the non-numeric legacy-metadata-value branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTcU2g7zscj5tVcxzXuBqQ