### PR TITLE
feat(site-host): show device Network Address on device detail page

### DIFF
--- a/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
+++ b/src/Haus.Site.Host/Devices/Detail/DeviceDetailView.razor
@@ -46,6 +46,12 @@
                   ReadOnly="true"
                   InputId="roomId"
                   Value="Device.RoomId"/>
+    <MudTextField T="string"
+                  Label="Network Address"
+                  FullWidth="true"
+                  ReadOnly="true"
+                  InputId="networkAddress"
+                  Value="@NetworkAddressDisplay"/>
 
     @if (Device.DeviceType == DeviceType.Light)
     {
@@ -73,6 +79,8 @@
     [Parameter] public required DeviceModel Device { get; set; }
 
     private bool _metadataExpanded;
+
+    private string NetworkAddressDisplay => Device.NetworkAddress?.ToString() ?? "Unknown";
 
     private async Task HandleDeleteClicked()
     {

--- a/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
+++ b/tests/Haus.Site.Host.Tests/Devices/Detail/DeviceDetailViewTests.cs
@@ -42,6 +42,23 @@ public class DeviceDetailViewTests : HausSiteTestContext
             page.FindMudTextFieldById<LightType>("lightType").Instance.GetState(x => x.Value)
         );
         Assert.Equal(device.RoomId, page.FindMudTextFieldById<long?>("roomId").Instance.GetState(x => x.Value));
+        Assert.Equal(
+            device.NetworkAddress.ToString(),
+            page.FindMudTextFieldById<string>("networkAddress").Instance.GetState(x => x.Value)
+        );
+    }
+
+    [Fact]
+    public void WhenDeviceNetworkAddressIsNullThenShowsUnknown()
+    {
+        var device = HausModelFactory.DeviceModel() with { NetworkAddress = null };
+
+        var page = Context.Render<DeviceDetailView>(opts =>
+        {
+            opts.Add(p => p.Device, device);
+        });
+
+        Assert.Equal("Unknown", page.FindMudTextFieldById<string>("networkAddress").Instance.GetState(x => x.Value));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds a "Network Address" row to the Device Details section of the device detail page, next to Room Id.
- Shows the device's `NetworkAddress` (`ushort?`) when present, or the literal string "Unknown" when null — matching the existing null-object convention already used for `ZigbeeConnectionStatusView`'s unknown status, rather than the blank-field pattern used elsewhere, which is ambiguous with "not yet loaded".
- This closes the diagnostic gap where a device's on-file network address couldn't be verified from the UI. A null `NetworkAddress` is a real failure signal: `ZigbeeOutboundRelay` silently drops lighting commands for devices with no network address, so this field makes that state visible without querying the database directly.

## Test plan
- [x] Added `WhenDeviceNetworkAddressIsNullThenShowsUnknown` bUnit test (null case)
- [x] Extended `WhenRenderedThenShowsDeviceInformation` to assert the populated case
- [x] `dotnet test tests/Haus.Site.Host.Tests` — 157/157 passing
- [x] `dotnet build` — green solution-wide (the one pre-existing failure, `Haus.Acceptance.Tests`' Playwright browser install needing root, reproduces identically on `main` and is unrelated to this change)
- [x] Fresh-eyes self-review completed, no blocking findings

Refs #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)