### PR TITLE
fix(zigbee): resolve stale NWK addresses on restart instead of dropping commands

### DIFF
--- a/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
+++ b/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
@@ -1,0 +1,162 @@
+# Design note — ZDP NWK_addr_req resolution fallback for stale NetworkAddress (issue #9)
+
+Status: architecture decided, ready for implementation.
+Scope basis: locked requirements from the work request (see below); do not re-litigate.
+Primary protocol reference: Zigbee spec **05-3474-23-csg** (CSA IoT), ZDP command reference —
+`NWK_addr_req` / `NWK_addr_rsp` (cluster 0x0000 request / 0x8000 response, ZDP profile 0x0000).
+Same reference class already cited by the deCONZ design note.
+
+## Problem (restated)
+
+`KnownDeviceTable` is rebuilt empty on every `Haus.Zigbee.Host` restart and is only populated by
+`DeviceInterview.InterviewAsync`, which fires solely on a live ZDP Device Announce. A previously
+paired device that hasn't re-announced since the last restart has `DeviceEntity.NetworkAddress ==
+null`, so `ZigbeeOutboundRelay.HandleLightingAsync` silently (now visibly, via
+`ZigbeeCommandDroppedEvent`) drops every lighting command to it. The deCONZ serial protocol has no
+bulk device-table read, so there's nothing to hydrate from at connect time — the fix has to be a
+per-command, on-demand resolution.
+
+## Wire format (NWK_addr_req / NWK_addr_rsp)
+
+Mirrors this codebase's existing ZDP codec shape (`Zdp/ActiveEndpointsRequest.cs`,
+`Zdp/SimpleDescriptorRequest.cs`): a leading `TransactionSequenceNumber` byte (the ZDP header byte
+every request/response in this codebase already includes), then the cluster-specific payload,
+all multi-byte fields little-endian.
+
+**Request** (cluster `0x0000`, 11 bytes):
+| Field | Bytes | Notes |
+|---|---|---|
+| TransactionSequenceNumber | 1 | |
+| IEEEAddr | 8 | target device's 64-bit IEEE address, LE |
+| RequestType | 1 | `0x00` = Single Device Response (only value this codebase needs — we only want the one NWK address, never the associated-device list) |
+| StartIndex | 1 | only meaningful for Extended Response; send `0x00` |
+
+**Response** (cluster `0x8000`, ≥12 bytes on success):
+| Field | Bytes | Notes |
+|---|---|---|
+| TransactionSequenceNumber | 1 | echoes the request |
+| Status | 1 | `ZdoStatus` (existing enum) |
+| IEEEAddrRemoteDevice | 8 | LE |
+| NWKAddrRemoteDevice | 2 | LE — the address we want |
+| NumAssocDev / StartIndex / AssocDevList | variable, optional | only present for Extended Response; a Single Device Response request must not receive them, but decode defensively (ignore trailing bytes) in case a stack sends them anyway |
+
+Decode returns `null` on a too-short payload, matching `ActiveEndpointsResponseCodec`'s existing
+defensive-truncation convention (a malformed frame from a real device must never throw and stop
+delivery to the other `IndicationReceived` subscribers).
+
+Request is sent as an APS broadcast to `0xFFFF` ("all devices, including sleeping end devices" —
+NWK broadcast address table, spec §3.6.5), ZDP endpoint `0x00` on both ends, profile `0x0000` —
+identical addressing shape to `DeviceInterview.SendZdpAsync`, just to a broadcast destination
+instead of a known unicast NWK address.
+
+## Where the logic lives
+
+New class `Haus.Zigbee/Coordinator/NetworkAddressResolver.cs`, sibling to `DeviceInterview`, not a
+method bolted onto it. `DeviceInterview` owns "orchestrate everything that happens when a device
+joins"; this is a narrower, single job ("given an IEEE address, ask the network for its current
+NWK address") with a different correlation shape (broadcast request → no NWK address known until
+the response arrives, so it cannot key on `(NetworkAddress, ClusterId, SequenceNumber)` the way
+`DeviceInterview.ResponseKey` does — only `SequenceNumber` is known up front). A separate small
+collaborator keeps that difference from leaking into `DeviceInterview` and keeps each class's
+correlation model simple, matching [[feedback_architecture_style]] (avoid god-like classes,
+separate event data from handling) and the existing pattern of small focused collaborators wired
+into `TransportComponents` (`PermitJoinController`, `AttributeReportListener`, `DeviceInterview`
+are all already separate, single-purpose classes).
+
+```csharp
+public class NetworkAddressResolver : IDisposable
+{
+    // ApsPollLoop.IndicationReceived, ApsSender, KnownDeviceTable — same collaborators
+    // DeviceInterview already takes.
+    public Task<ushort?> ResolveAsync(IeeeAddress ieeeAddress, CancellationToken token);
+}
+```
+
+- Registers a `TaskCompletionSource<ApsDataIndicationFrame>` keyed by its own ZDP transaction
+  sequence number (own `ByteSequenceCounter`, own dictionary — independent of `DeviceInterview`'s).
+- On `IndicationReceived`, claims the indication only when `ProfileId == 0x0000 && ClusterId ==
+  0x8000` (NWK_addr_rsp) and the decoded transaction sequence number matches a pending entry;
+  otherwise ignores it. `AttributeReportListener` and `DeviceInterview` already coexist as
+  independent subscribers on this same shared event, each filtering to what they own — this is a
+  third, following the same convention, not a new pattern.
+- Awaits the pending response bounded by a timeout (constructor param, default matching
+  `DeviceInterview.DefaultResponseTimeout` = 30s — this is the same weight of ZDP round trip),
+  using the same `CancellationTokenSource` + `WaitAsync(linked.Token)` shape as
+  `DeviceInterview.SendAsync` / `ApsSender.SendAsync`.
+- **Catches its own timeout internally and returns `null`** rather than throwing
+  `OperationCanceledException` out to the caller. This is a deliberate departure from
+  `DeviceInterview.SendAsync`/`ApsSender.SendAsync` (which do throw on timeout): those calls sit
+  mid-interview where a timeout aborts the whole interview (exception is the right signal).
+  Here, "no answer" is an expected, first-class outcome the caller (`ZigbeeOutboundRelay`) branches
+  on to fall back to today's drop-and-log behavior — a `Task<ushort?>` result reads as intent
+  directly at the call site instead of `try/catch` used for control flow.
+- On success (`Status == Success`), updates `KnownDeviceTable` — preserving any already-known
+  endpoints for that IEEE address (`TryGet` first; empty list if none) — the same
+  "resolve → update the table" step `DeviceInterview.InterviewAsync` already performs.
+
+`IZigbeeCoordinator` gains:
+```csharp
+Task<ushort?> ResolveNetworkAddressAsync(IeeeAddress ieeeAddress, CancellationToken token);
+```
+`ZigbeeCoordinator` delegates to `CurrentComponents().NetworkAddressResolver.ResolveAsync(...)`.
+`TransportComponents` gains a `NetworkAddressResolver` field, built in `BuildTransportComponents`
+and disposed in `DisposeComponents`, exactly like `DeviceInterview` today.
+
+## Wiring in `ZigbeeOutboundRelay`
+
+`HandleLightingAsync` currently drops straight to `HandleMissingNetworkAddressAsync` (added by
+PR #66, unchanged) when `device.NetworkAddress` is null. New flow:
+
+```
+networkAddress = device.NetworkAddress ?? await ResolveNetworkAddressAsync(device, token)
+null  -> HandleMissingNetworkAddressAsync(device)   // unchanged: log warning + ZigbeeCommandDroppedEvent
+value -> proceed exactly as today, using the resolved address
+```
+
+`ResolveNetworkAddressAsync(DeviceModel device, token)`:
+1. `ExternalIdConverter.TryParseAddress(device.ExternalId, ...)` — mirrors the converter already
+   used elsewhere in this codebase; an unparseable `ExternalId` resolves to `null` (falls back to
+   drop, same as a resolution timeout).
+2. `coordinator.ResolveNetworkAddressAsync(ieeeAddress, token)`.
+3. On success: `addressRegistry.Register(...)` (same registry `SyncDevicesAsync` populates), then
+   publish `DeviceDiscoveredEvent` so `Haus.Web.Host`'s existing
+   `DeviceDiscoveredEventHandler`/`DeviceEntity.UpdateFromDiscoveredDevice` path persists the
+   resolved `NetworkAddress` — no new DB-write path needed, this event already updates an existing
+   `DeviceEntity` in place.
+
+**Important correctness point found during this design pass:** `DeviceDiscoveredEvent` carries
+`DeviceType`, and `DeviceEntity.UpdateFromDiscoveredDevice` **unconditionally overwrites**
+`DeviceType` (and derives `LightType` from it) on every event, no merge. `DevicesMapper` (used by
+the full discovery sync path) always sets `DeviceType.Unknown` because at that call site the
+coordinator genuinely doesn't know the type. This fallback path is different: it fires on *every*
+lighting command to a stale device, and the triggering MQTT message already carries the device's
+current `DeviceModel` — including its already-classified `DeviceType`, `LightType`-implying
+metadata, and `Metadata`. Publishing `DeviceType.Unknown` here would silently reclassify an
+already-known light back to Unknown on the very first stale-address command after every restart —
+a regression this fix must not introduce. So the published event must carry `device.DeviceType`
+and `device.Metadata` from the inbound command's `DeviceModel`, not `Unknown`:
+```csharp
+new DeviceDiscoveredEvent(device.ExternalId, device.DeviceType, device.Metadata, networkAddress)
+```
+4. Return the resolved address so the caller proceeds to send the original lighting command in the
+   same handler invocation (no second round trip through MQTT).
+
+`HandleMissingNetworkAddressAsync` is untouched — diagnostics visibility from PR #66 is preserved
+verbatim for the genuine-timeout / unparseable-IEEE case.
+
+## Test seams (no real hardware, no real DB — per hard constraint)
+
+- **`Haus.Zigbee.Tests`**: `NwkAddrRequestCodec`/`NwkAddrResponseCodec` encode/decode round-trips
+  and truncation handling (mirror `ActiveEndpointsResponseCodec`'s test shape). `NetworkAddressResolver`
+  tests reuse `FakeDeconzDongle`/`FakeSerialTransport` exactly like `DeviceInterviewTests` — inject
+  an `IndicationBody` on cluster `0x8000` released after the broadcast request is sent, plus a
+  timeout case with no `ReleaseAfterSend` registered (mirrors
+  `WhenTheActiveEndpointsRequestNeverReceivesAResponseThenTheInterviewAbortsWithoutJoiningTheDevice`).
+- **`Haus.Zigbee.Host.Tests`**: extend `FakeZigbeeCoordinator` with a scriptable
+  `ResolveNetworkAddressAsync` (e.g. `NetworkAddressToReturn`, recorded call list) — same pattern
+  as its existing `DeviceInfoToReturn`/`ConfirmToReturn`. New `ZigbeeOutboundRelayTests` cases:
+  resolve-success sends the original command using the resolved address and publishes
+  `DeviceDiscoveredEvent` with the *original* `DeviceType`/`Metadata` (not `Unknown`); resolve-null
+  falls back to the existing drop+`ZigbeeCommandDroppedEvent` behavior unchanged.
+- Both suites run entirely against the existing fake serial transport / in-memory fakes — no serial
+  port, no MQTT broker, no EF/database involved in either project's tests.

--- a/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
+++ b/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
@@ -104,25 +104,65 @@ and disposed in `DisposeComponents`, exactly like `DeviceInterview` today.
 
 ## Wiring in `ZigbeeOutboundRelay`
 
-`HandleLightingAsync` currently drops straight to `HandleMissingNetworkAddressAsync` (added by
-PR #66, unchanged) when `device.NetworkAddress` is null. New flow:
+**Revised after fresh-eyes review** (see "Not blocking the shared MQTT pump" below): the resolve
+does *not* run inline on the command that discovered the stale address. `HandleLightingAsync`
+still drops straight to `HandleMissingNetworkAddressAsync` (added by PR #66, unchanged) when
+`device.NetworkAddress` is null, but now *also* fires the resolution off as a detached background
+task so the *next* command for that device succeeds instead:
 
 ```
-networkAddress = device.NetworkAddress ?? await ResolveNetworkAddressAsync(device, token)
-null  -> HandleMissingNetworkAddressAsync(device)   // unchanged: log warning + ZigbeeCommandDroppedEvent
-value -> proceed exactly as today, using the resolved address
+if device.NetworkAddress is null:
+    HandleMissingNetworkAddressAsync(device)   // unchanged: log warning + ZigbeeCommandDroppedEvent
+    TriggerBackgroundResolve(device)           // detached, deduped per ExternalId, doesn't block this call
+    return
+// device.NetworkAddress present -> proceed exactly as today
 ```
 
-`ResolveNetworkAddressAsync(DeviceModel device, token)`:
+`TriggerBackgroundResolve` dedupes on `DeviceModel.ExternalId` via a `ConcurrentDictionary` so
+repeated commands for the same still-unresolved device (e.g. several lighting commands queued up
+right after a restart) don't each fire their own broadcast — only one resolution is in flight per
+device at a time.
+
+`ResolveNetworkAddressAsync(DeviceModel device, token)` (now `void`-returning, called only from the
+background path):
 1. `ExternalIdConverter.TryParseAddress(device.ExternalId, ...)` — mirrors the converter already
-   used elsewhere in this codebase; an unparseable `ExternalId` resolves to `null` (falls back to
-   drop, same as a resolution timeout).
-2. `coordinator.ResolveNetworkAddressAsync(ieeeAddress, token)`.
+   used elsewhere in this codebase; an unparseable `ExternalId` is a no-op.
+2. `coordinator.ResolveNetworkAddressAsync(ieeeAddress, token)`; a timeout/no-answer is also a
+   no-op — the device stays unresolved until the next dropped command retriggers this.
 3. On success: `addressRegistry.Register(...)` (same registry `SyncDevicesAsync` populates), then
    publish `DeviceDiscoveredEvent` so `Haus.Web.Host`'s existing
    `DeviceDiscoveredEventHandler`/`DeviceEntity.UpdateFromDiscoveredDevice` path persists the
    resolved `NetworkAddress` — no new DB-write path needed, this event already updates an existing
    `DeviceEntity` in place.
+
+### Not blocking the shared MQTT pump
+
+The original version of this design had `HandleLightingAsync` `await` the resolve inline and send
+the original command using the resolved address in the same call. A fresh-eyes review caught that
+this runs inside `HausMqttClient`'s single serialized message handler
+(`MqttMessageHandler` → each subscription's `ExecuteAsync`, awaited via `Task.WhenAll` before the
+managed MQTT client dispatches the next message) — so a stale-address command would block *every*
+other incoming MQTT command/message for up to the resolver's 30s timeout. Firing the resolution
+off detached (not awaited by `HandleCommandAsync`) removes that blocking without shortening the
+timeout: the current command still drops immediately (same visible behavior as before this whole
+feature — PR #66's drop-and-log), and the resolved address becomes available for the *next*
+command via the same `DeviceDiscoveredEvent` → persisted `DeviceEntity.NetworkAddress` path.
+
+### RequestId collision (re-checked, not fixed here)
+
+`ApsSender._pendingConfirms` correlates every outstanding APS confirm by a single `byte RequestId`
+across *all* callers of `ApsSender.SendAsync` (`CommandSender`, `DeviceInterview`, and now
+`NetworkAddressResolver`), but each caller owns an *independent* `ByteSequenceCounter` for that
+field (see the explicit comment in `CommandSender`: "the ZCL transaction sequence number and the
+APS request id are distinct concerns, so each layer owns its own counter here"). Two concurrent
+in-flight sends from different collaborators can in principle land on the same byte value and
+overwrite each other's pending-confirm entry. This is a pre-existing property of the codebase
+(already shared between `CommandSender` and `DeviceInterview` before this PR); `NetworkAddressResolver`
+becomes a third participant in the same shared keyspace but does not introduce a new failure mode.
+Centralizing RequestId issuance in `ApsSender` would close this properly, but touches two
+established collaborators outside this PR's scope — left as a follow-up rather than folded in here.
+The new device-backfill sweep (below) mitigates its own added exposure by resolving devices
+sequentially rather than firing many broadcasts concurrently at startup.
 
 **Important correctness point found during this design pass:** `DeviceDiscoveredEvent` carries
 `DeviceType`, and `DeviceEntity.UpdateFromDiscoveredDevice` **unconditionally overwrites**

--- a/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
+++ b/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
@@ -207,6 +207,40 @@ concurrently — see the RequestId-collision note above for why that matters):
    overwriting a known device), so the same landmine documented above for the reactive path doesn't
    apply here either — this path was already safe against it.
 
+Correction to the RequestId-collision note above: "resolving devices sequentially" only guarantees
+no two broadcasts are in flight *within the sweep itself*. It does not prevent the sweep's resolve
+for one device from overlapping a *reactive* background resolve (`ZigbeeOutboundRelay`'s
+`TriggerBackgroundResolve`) for a different device racing in from a queued MQTT command at the same
+time — those two collaborators don't share a dedupe set. That overlap is a redundant broadcast at
+worst (both still go through `NetworkAddressResolver`'s single `Interlocked`-based counters, so
+their transaction sequence numbers and request IDs never collide with each other), not a
+correctness problem, so it's left as-is rather than adding a second dedupe layer across collaborators.
+
+### Second fresh-eyes review pass: lost-update race in `KnownDeviceTable` (fixed)
+
+A second review round, run after the pump-blocking/IEEE-verification/RequestId findings above were
+already addressed, found one more real gap: `NetworkAddressResolver.RecordResolvedAddress` did a
+`TryGet` (read the existing entry's `Endpoints`) followed by a separate `AddOrUpdate` (write a
+rebuilt `ZigbeeDevice`) — two independent `ConcurrentDictionary` operations, not one atomic step.
+`DeviceInterview.InterviewAsync` does its own unsynchronized `AddOrUpdate` with a freshly-discovered
+endpoint list. If a device's own re-announce interview completed *between* the resolver's `TryGet`
+and its `AddOrUpdate` for that same device, the resolver's write would silently clobber the
+interview's newly-discovered endpoints with the stale ones it read a moment earlier. The resolved
+*address* was always correct either way (the resolver only ever writes the value it just verified),
+but endpoints could be lost — and the new startup sweep meaningfully raises the odds of exactly
+this interleaving, since it proactively resolves every known device right at connect, precisely
+when devices are most likely to be re-announcing after the same restart.
+
+Fixed by giving `KnownDeviceTable` an atomic `UpdateNetworkAddress(ieeeAddress, networkAddress)`
+method built on `ConcurrentDictionary.AddOrUpdate`'s factory overload — the read of the existing
+entry and the write of the updated one now happen as a single dictionary operation (retried against
+the latest value on contention, per `ConcurrentDictionary`'s documented semantics), so there is no
+window between them for a concurrent `AddOrUpdate` to land in. `NetworkAddressResolver` now calls
+this instead of doing its own `TryGet` + `AddOrUpdate`. `DeviceInterview.InterviewAsync` still does
+a plain `AddOrUpdate` for its own full-device write (network address, endpoints, and everything
+else it just discovered) — that write is intentionally the fresher, complete replacement in this
+race, and is unaffected by this fix.
+
 Why fold this into `DeviceBackfillService` instead of a new collaborator: a separate sweep that
 resolved-then-published its own `DeviceDiscoveredEvent` would need its own answer to "what
 DeviceType do I publish," and `ZigbeeDevice` (from `KnownDeviceTable`) carries no DeviceType at

--- a/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
+++ b/docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md
@@ -178,11 +178,40 @@ and `device.Metadata` from the inbound command's `DeviceModel`, not `Unknown`:
 ```csharp
 new DeviceDiscoveredEvent(device.ExternalId, device.DeviceType, device.Metadata, networkAddress)
 ```
-4. Return the resolved address so the caller proceeds to send the original lighting command in the
-   same handler invocation (no second round trip through MQTT).
+(Step 4 in the original plan — "return the resolved address so the caller proceeds to send the
+original command in the same handler invocation" — no longer applies; see "Not blocking the shared
+MQTT pump" above. The background resolve's only remaining job is steps 1-3.)
 
 `HandleMissingNetworkAddressAsync` is untouched — diagnostics visibility from PR #66 is preserved
 verbatim for the genuine-timeout / unparseable-IEEE case.
+
+## Startup sweep: resolving already-known devices proactively
+
+Added scope beyond the original request: rather than waiting for a lighting command to discover a
+stale address reactively, `DeviceBackfillService` — already invoked once per connect, off the
+connect hot path (`ZigbeeHausBridge.TryConnectAsync` → detached `BackfillSafelyAsync`) — now also
+resolves each already-known device's `NetworkAddress` before re-reading its Basic cluster, reusing
+`IZigbeeCoordinator.ResolveNetworkAddressAsync` (no new resolution logic; this is the same
+`NetworkAddressResolver` the reactive path uses).
+
+`BackfillDeviceAsync` per device, in order (unchanged: `BackfillAsync` iterates sequentially, not
+concurrently — see the RequestId-collision note above for why that matters):
+1. `coordinator.ResolveNetworkAddressAsync(device.IeeeAddress, token) ?? device.NetworkAddress` — a
+   successful resolve also updates `KnownDeviceTable` as a side effect (`NetworkAddressResolver`'s
+   existing behavior), so the subsequent `ReadDeviceInfoAsync` call (which looks the device back up
+   in `KnownDeviceTable` by IEEE address) automatically uses the freshened address too. No answer
+   falls back to the address already on record, exactly like `NetworkAddressToReturn: null` in the
+   reactive path — best-effort, not a hard failure.
+2. `ReadDeviceInfoAsync` and the publish-if-classified logic are unchanged from the existing
+   backfill behavior; DeviceType/Metadata still come from a fresh Basic-cluster read (not "Unknown"
+   overwriting a known device), so the same landmine documented above for the reactive path doesn't
+   apply here either — this path was already safe against it.
+
+Why fold this into `DeviceBackfillService` instead of a new collaborator: a separate sweep that
+resolved-then-published its own `DeviceDiscoveredEvent` would need its own answer to "what
+DeviceType do I publish," and `ZigbeeDevice` (from `KnownDeviceTable`) carries no DeviceType at
+all — reusing `DeviceBackfillService`'s existing Basic-cluster-read-then-classify-then-publish flow
+avoids reinventing that safeguard.
 
 ## Test seams (no real hardware, no real DB — per hard constraint)
 

--- a/src/Haus.Zigbee.Host/Zigbee/Services/DeviceBackfillService.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/DeviceBackfillService.cs
@@ -32,13 +32,18 @@ public class DeviceBackfillService(
     {
         try
         {
+            // A resolve refreshes the address in case it changed since this device was last seen;
+            // no answer falls back to the address already on record rather than abandoning backfill.
+            var networkAddress =
+                await coordinator.ResolveNetworkAddressAsync(device.IeeeAddress, token) ?? device.NetworkAddress;
+
             var info = await coordinator.ReadDeviceInfoAsync(device.IeeeAddress, token);
             if (info == null)
                 return;
 
             var joined = new ZigbeeDeviceJoined(
                 device.IeeeAddress,
-                device.NetworkAddress,
+                networkAddress,
                 device.Endpoints,
                 info.ManufacturerName,
                 info.ModelIdentifier

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -89,7 +89,8 @@ public class ZigbeeOutboundRelay(
         }
 
         var device = command.Payload.Device;
-        if (device.NetworkAddress is not { } networkAddress)
+        var resolvedNetworkAddress = device.NetworkAddress ?? await ResolveNetworkAddressAsync(device, token);
+        if (resolvedNetworkAddress is not { } networkAddress)
         {
             await HandleMissingNetworkAddressAsync(device);
             return;
@@ -115,6 +116,18 @@ public class ZigbeeOutboundRelay(
                     confirm.ConfirmStatus
                 );
         }
+    }
+
+    // A previously-paired device whose NetworkAddress went stale over a Host restart can still be
+    // reached by broadcasting for its current short address before giving up. An ExternalId that
+    // does not parse to an IEEE address, or a broadcast nobody answers, both resolve to null and
+    // fall through to the same drop-and-log path as before.
+    private async Task<ushort?> ResolveNetworkAddressAsync(DeviceModel device, CancellationToken token)
+    {
+        if (!ExternalIdConverter.TryParseAddress(device.ExternalId, out var ieeeAddress))
+            return null;
+
+        return await coordinator.ResolveNetworkAddressAsync(ieeeAddress, token);
     }
 
     private async Task HandleMissingNetworkAddressAsync(DeviceModel device)

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -127,7 +127,20 @@ public class ZigbeeOutboundRelay(
         if (!ExternalIdConverter.TryParseAddress(device.ExternalId, out var ieeeAddress))
             return null;
 
-        return await coordinator.ResolveNetworkAddressAsync(ieeeAddress, token);
+        if (await coordinator.ResolveNetworkAddressAsync(ieeeAddress, token) is not { } networkAddress)
+            return null;
+
+        addressRegistry.Register(networkAddress, device.ExternalId);
+
+        // DeviceEntity.UpdateFromDiscoveredDevice unconditionally overwrites DeviceType, so the
+        // event must carry this command's already-classified DeviceType/Metadata -- publishing
+        // DeviceType.Unknown here would silently reclassify a known light back to Unknown on every
+        // stale-address command after a restart.
+        var hausMqttClient = await mqttClientFactory.CreateClient();
+        await hausMqttClient.PublishHausEventAsync(
+            new DeviceDiscoveredEvent(device.ExternalId, device.DeviceType, device.Metadata, networkAddress)
+        );
+        return networkAddress;
     }
 
     private async Task HandleMissingNetworkAddressAsync(DeviceModel device)

--- a/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
+++ b/src/Haus.Zigbee.Host/Zigbee/Services/ZigbeeOutboundRelay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Core.Models;
@@ -35,6 +36,11 @@ public class ZigbeeOutboundRelay(
     // Per the Zigbee APS spec, a confirm status of 0x00 is APS_SUCCESS; anything else is a delivery
     // failure reported back from the stack for that specific request.
     private const byte SuccessConfirmStatus = 0x00;
+
+    // Tracks which devices currently have a background resolution in flight, keyed by ExternalId,
+    // so repeated commands for the same stale device while one is already pending don't each fire
+    // their own broadcast.
+    private readonly ConcurrentDictionary<string, byte> _pendingResolutions = new();
 
     public async Task HandleCommandAsync(MqttApplicationMessage message, CancellationToken token)
     {
@@ -89,10 +95,10 @@ public class ZigbeeOutboundRelay(
         }
 
         var device = command.Payload.Device;
-        var resolvedNetworkAddress = device.NetworkAddress ?? await ResolveNetworkAddressAsync(device, token);
-        if (resolvedNetworkAddress is not { } networkAddress)
+        if (device.NetworkAddress is not { } networkAddress)
         {
             await HandleMissingNetworkAddressAsync(device);
+            TriggerBackgroundResolve(device);
             return;
         }
 
@@ -119,16 +125,45 @@ public class ZigbeeOutboundRelay(
     }
 
     // A previously-paired device whose NetworkAddress went stale over a Host restart can still be
-    // reached by broadcasting for its current short address before giving up. An ExternalId that
-    // does not parse to an IEEE address, or a broadcast nobody answers, both resolve to null and
-    // fall through to the same drop-and-log path as before.
-    private async Task<ushort?> ResolveNetworkAddressAsync(DeviceModel device, CancellationToken token)
+    // reached by broadcasting for its current short address -- but that broadcast is bounded by a
+    // 30s timeout, and this relay runs inside the MQTT client's single serialized message handler,
+    // so awaiting it inline here would block every other incoming command for up to 30s. Instead
+    // the current command drops immediately (HandleMissingNetworkAddressAsync, unchanged) and the
+    // resolution runs detached so the *next* command for this device can succeed without waiting.
+    private void TriggerBackgroundResolve(DeviceModel device)
+    {
+        if (!_pendingResolutions.TryAdd(device.ExternalId, 0))
+            return;
+
+        _ = ResolveInBackgroundAsync(device);
+    }
+
+    private async Task ResolveInBackgroundAsync(DeviceModel device)
+    {
+        try
+        {
+            await ResolveNetworkAddressAsync(device, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to resolve network address in background for {@ExternalId}", device.ExternalId);
+        }
+        finally
+        {
+            _pendingResolutions.TryRemove(device.ExternalId, out _);
+        }
+    }
+
+    // An ExternalId that does not parse to an IEEE address, or a broadcast nobody answers, both
+    // resolve to null and this quietly does nothing further -- the device stays unresolved until
+    // the next dropped command retriggers this.
+    private async Task ResolveNetworkAddressAsync(DeviceModel device, CancellationToken token)
     {
         if (!ExternalIdConverter.TryParseAddress(device.ExternalId, out var ieeeAddress))
-            return null;
+            return;
 
         if (await coordinator.ResolveNetworkAddressAsync(ieeeAddress, token) is not { } networkAddress)
-            return null;
+            return;
 
         addressRegistry.Register(networkAddress, device.ExternalId);
 
@@ -140,7 +175,6 @@ public class ZigbeeOutboundRelay(
         await hausMqttClient.PublishHausEventAsync(
             new DeviceDiscoveredEvent(device.ExternalId, device.DeviceType, device.Metadata, networkAddress)
         );
-        return networkAddress;
     }
 
     private async Task HandleMissingNetworkAddressAsync(DeviceModel device)

--- a/src/Haus.Zigbee/Coordinator/KnownDeviceTable.cs
+++ b/src/Haus.Zigbee/Coordinator/KnownDeviceTable.cs
@@ -15,6 +15,21 @@ public class KnownDeviceTable
         _devices[device.IeeeAddress] = device;
     }
 
+    // A separate read-then-write (TryGet an existing entry's Endpoints, then AddOrUpdate a rebuilt
+    // ZigbeeDevice) is not atomic against a concurrent full AddOrUpdate -- e.g. an on-demand address
+    // resolution racing a device's own re-announce could silently lose the announce's freshly
+    // discovered endpoints. ConcurrentDictionary.AddOrUpdate's factories are retried against the
+    // latest value on a concurrent write, so this can only ever apply on top of whatever the most
+    // recent entry actually is.
+    public void UpdateNetworkAddress(IeeeAddress ieeeAddress, ushort networkAddress)
+    {
+        _devices.AddOrUpdate(
+            ieeeAddress,
+            addValueFactory: _ => new ZigbeeDevice(ieeeAddress, networkAddress, []),
+            updateValueFactory: (_, existing) => existing with { NetworkAddress = networkAddress }
+        );
+    }
+
     public IReadOnlyList<ZigbeeDevice> GetDevices()
     {
         return _devices.Values.ToList();

--- a/src/Haus.Zigbee/Coordinator/NetworkAddressResolver.cs
+++ b/src/Haus.Zigbee/Coordinator/NetworkAddressResolver.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Zigbee.Connection;
+using Haus.Zigbee.Models;
+using Haus.Zigbee.Serial.Frames;
+using Haus.Zigbee.Zdp;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Haus.Zigbee.Coordinator;
+
+// Resolves an IEEE address to its current NWK (short) address on demand by broadcasting a ZDP
+// NWK_addr_req and waiting for the one device that owns that IEEE address to answer. This is a
+// narrower job than DeviceInterview's full join orchestration and has a different correlation shape:
+// a broadcast request means no NWK address is known up front, so pending responses can only be keyed
+// by transaction sequence number, not by (address, cluster, sequence) the way DeviceInterview does.
+public class NetworkAddressResolver : IDisposable
+{
+    private const ushort ZdpProfileId = 0x0000;
+    private const ushort NwkAddrRequestCluster = 0x0000;
+    private const ushort NwkAddrResponseCluster = 0x8000;
+    private const ushort BroadcastAddress = 0xffff;
+    private const byte ZdpEndpoint = 0x00;
+    private const byte DefaultTxOptions = 0x00;
+    private const byte DefaultRadius = 0x00;
+
+    private static readonly TimeSpan DefaultResponseTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly ApsPollLoop _pollLoop;
+    private readonly ApsSender _sender;
+    private readonly KnownDeviceTable _knownDeviceTable;
+    private readonly TimeSpan _responseTimeout;
+    private readonly ILogger<NetworkAddressResolver> _logger;
+    private readonly ConcurrentDictionary<byte, TaskCompletionSource<ApsDataIndicationFrame>> _pendingResponses = new();
+    private readonly ByteSequenceCounter _transactionSequenceNumber = new();
+    private readonly ByteSequenceCounter _requestId = new();
+
+    public NetworkAddressResolver(
+        ApsPollLoop pollLoop,
+        ApsSender sender,
+        KnownDeviceTable knownDeviceTable,
+        TimeSpan? responseTimeout = null,
+        ILogger<NetworkAddressResolver>? logger = null
+    )
+    {
+        _pollLoop = pollLoop;
+        _sender = sender;
+        _knownDeviceTable = knownDeviceTable;
+        _responseTimeout = responseTimeout ?? DefaultResponseTimeout;
+        _logger = logger ?? NullLogger<NetworkAddressResolver>.Instance;
+        _pollLoop.IndicationReceived += OnIndicationReceived;
+    }
+
+    public void Dispose()
+    {
+        _pollLoop.IndicationReceived -= OnIndicationReceived;
+        GC.SuppressFinalize(this);
+    }
+
+    // Returns the resolved NWK address, or null when no device answered before the timeout. "No
+    // answer" is an expected outcome the caller branches on, so a timeout resolves to null here
+    // rather than throwing OperationCanceledException the way DeviceInterview/ApsSender do.
+    public async Task<ushort?> ResolveAsync(IeeeAddress ieeeAddress, CancellationToken token)
+    {
+        var sequenceNumber = _transactionSequenceNumber.Next();
+        var pending = new TaskCompletionSource<ApsDataIndicationFrame>();
+        _pendingResponses[sequenceNumber] = pending;
+        try
+        {
+            SendBroadcastRequest(ieeeAddress, sequenceNumber, token);
+
+            using var timeout = new CancellationTokenSource(_responseTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, timeout.Token);
+            var indication = await pending.Task.WaitAsync(linked.Token);
+            return RecordResolvedAddress(ieeeAddress, indication);
+        }
+        catch (OperationCanceledException) when (!token.IsCancellationRequested)
+        {
+            return null;
+        }
+        finally
+        {
+            _pendingResponses.TryRemove(sequenceNumber, out _);
+        }
+    }
+
+    private void SendBroadcastRequest(IeeeAddress ieeeAddress, byte sequenceNumber, CancellationToken token)
+    {
+        var asdu = NwkAddrRequestCodec.Encode(new NwkAddrRequest(sequenceNumber, ieeeAddress));
+        var request = new ApsDataRequestFrame(
+            SequenceNumber: 0,
+            RequestId: _requestId.Next(),
+            Destination: ApsDestination.Nwk(BroadcastAddress, ZdpEndpoint),
+            ProfileId: ZdpProfileId,
+            ClusterId: NwkAddrRequestCluster,
+            SourceEndpoint: ZdpEndpoint,
+            AsduPayload: asdu,
+            TxOptions: DefaultTxOptions,
+            Radius: DefaultRadius
+        );
+        Forget(_sender.SendAsync(request, token));
+    }
+
+    private ushort? RecordResolvedAddress(IeeeAddress ieeeAddress, ApsDataIndicationFrame indication)
+    {
+        var response = NwkAddrResponseCodec.Decode(indication.AsduPayload);
+        if (response is null || response.Status != ZdoStatus.Success)
+            return null;
+
+        var endpoints = _knownDeviceTable.TryGet(ieeeAddress, out var existing) ? existing.Endpoints : [];
+        _knownDeviceTable.AddOrUpdate(new ZigbeeDevice(ieeeAddress, response.NetworkAddress, endpoints));
+        return response.NetworkAddress;
+    }
+
+    // This resolver is one of several independent listeners on the shared IndicationReceived event,
+    // so an indication it does not own simply belongs to someone else -- it is ignored silently
+    // rather than warn-logged the way DeviceInterview's single-owner correlation does.
+    private void OnIndicationReceived(object? sender, ApsIndicationReceived received)
+    {
+        var indication = received.Indication;
+        if (indication.ProfileId != ZdpProfileId || indication.ClusterId != NwkAddrResponseCluster)
+            return;
+        if (indication.AsduPayload.Length == 0)
+            return;
+
+        var sequenceNumber = indication.AsduPayload[0];
+        if (_pendingResponses.TryRemove(sequenceNumber, out var pending))
+            pending.SetResult(indication);
+    }
+
+    // The broadcast send is not awaited here: this protocol layer treats the NWK_addr_rsp indication
+    // itself as completion. Observing the detached send's outcome keeps a faulted or timed-out send
+    // (ApsSender ends a confirm timeout Canceled, not Faulted) from later surfacing as an
+    // unobserved-task exception.
+    private void Forget(Task task)
+    {
+        task.ContinueWith(
+            completed =>
+            {
+                if (completed.IsFaulted)
+                    _logger.LogError(completed.Exception, "Detached NWK-address broadcast task faulted");
+                else if (completed.IsCanceled)
+                    _logger.LogWarning("Detached NWK-address broadcast task timed out or was canceled");
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.NotOnRanToCompletion,
+            TaskScheduler.Default
+        );
+    }
+}

--- a/src/Haus.Zigbee/Coordinator/NetworkAddressResolver.cs
+++ b/src/Haus.Zigbee/Coordinator/NetworkAddressResolver.cs
@@ -111,8 +111,7 @@ public class NetworkAddressResolver : IDisposable
         if (response.IeeeAddress != ieeeAddress)
             return null;
 
-        var endpoints = _knownDeviceTable.TryGet(ieeeAddress, out var existing) ? existing.Endpoints : [];
-        _knownDeviceTable.AddOrUpdate(new ZigbeeDevice(ieeeAddress, response.NetworkAddress, endpoints));
+        _knownDeviceTable.UpdateNetworkAddress(ieeeAddress, response.NetworkAddress);
         return response.NetworkAddress;
     }
 

--- a/src/Haus.Zigbee/Coordinator/NetworkAddressResolver.cs
+++ b/src/Haus.Zigbee/Coordinator/NetworkAddressResolver.cs
@@ -108,6 +108,8 @@ public class NetworkAddressResolver : IDisposable
         var response = NwkAddrResponseCodec.Decode(indication.AsduPayload);
         if (response is null || response.Status != ZdoStatus.Success)
             return null;
+        if (response.IeeeAddress != ieeeAddress)
+            return null;
 
         var endpoints = _knownDeviceTable.TryGet(ieeeAddress, out var existing) ? existing.Endpoints : [];
         _knownDeviceTable.AddOrUpdate(new ZigbeeDevice(ieeeAddress, response.NetworkAddress, endpoints));

--- a/src/Haus.Zigbee/Coordinator/TransportComponents.cs
+++ b/src/Haus.Zigbee/Coordinator/TransportComponents.cs
@@ -18,7 +18,8 @@ internal sealed class TransportComponents(
     ApsSender sender,
     CommandSender commandSender,
     AttributeReportListener attributeReportListener,
-    DeviceInterview deviceInterview
+    DeviceInterview deviceInterview,
+    NetworkAddressResolver networkAddressResolver
 ) : IDisposable
 {
     public ISerialTransport Transport { get; } = transport;
@@ -30,12 +31,14 @@ internal sealed class TransportComponents(
     public CommandSender CommandSender { get; } = commandSender;
     public AttributeReportListener AttributeReportListener { get; } = attributeReportListener;
     public DeviceInterview DeviceInterview { get; } = deviceInterview;
+    public NetworkAddressResolver NetworkAddressResolver { get; } = networkAddressResolver;
 
     // Channel, Connection, PollLoop, PermitJoinController, and CommandSender hold no unmanaged
     // resources and subscribe to nothing on their own -- only the members disposed below do, so
     // only those need tearing down here.
     public void Dispose()
     {
+        NetworkAddressResolver.Dispose();
         DeviceInterview.Dispose();
         AttributeReportListener.Dispose();
         Sender.Dispose();

--- a/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
+++ b/src/Haus.Zigbee/Coordinator/ZigbeeCoordinator.cs
@@ -116,6 +116,11 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
         return await components.DeviceInterview.ReadBasicInfoAsync(device.NetworkAddress, device.Endpoints, token);
     }
 
+    public Task<ushort?> ResolveNetworkAddressAsync(IeeeAddress ieeeAddress, CancellationToken token)
+    {
+        return CurrentComponents().NetworkAddressResolver.ResolveAsync(ieeeAddress, token);
+    }
+
     public Task SetPermitJoinAsync(bool enabled, CancellationToken token)
     {
         return CurrentComponents().PermitJoinController.SetPermitJoinAsync(enabled, token);
@@ -182,6 +187,12 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
             _knownDeviceTable,
             logger: _loggerFactory.CreateLogger<DeviceInterview>()
         );
+        var networkAddressResolver = new NetworkAddressResolver(
+            pollLoop,
+            sender,
+            _knownDeviceTable,
+            logger: _loggerFactory.CreateLogger<NetworkAddressResolver>()
+        );
 
         attributeReportListener.AttributeReported += RelayAttributeReport;
         deviceInterview.DeviceJoined += RelayDeviceJoined;
@@ -195,7 +206,8 @@ public class ZigbeeCoordinator : IZigbeeCoordinator
             sender,
             commandSender,
             attributeReportListener,
-            deviceInterview
+            deviceInterview,
+            networkAddressResolver
         );
     }
 

--- a/src/Haus.Zigbee/IZigbeeCoordinator.cs
+++ b/src/Haus.Zigbee/IZigbeeCoordinator.cs
@@ -25,6 +25,11 @@ public interface IZigbeeCoordinator : IDisposable
     // re-reads its Basic cluster, the same way a fresh device-interview would.
     Task<ZigbeeDeviceInfo?> ReadDeviceInfoAsync(IeeeAddress ieeeAddress, CancellationToken token);
 
+    // Broadcasts a ZDP NWK_addr_req to discover the current short address of a device known only by
+    // its IEEE address, for a previously-paired device that has not re-announced since the last
+    // restart. Returns null when no device answers before the request times out.
+    Task<ushort?> ResolveNetworkAddressAsync(IeeeAddress ieeeAddress, CancellationToken token);
+
     Task SetPermitJoinAsync(bool enabled, CancellationToken token);
 
     Task<ApsDataConfirm> SendCommandAsync(ZigbeeCommandRequest request, CancellationToken token);

--- a/src/Haus.Zigbee/Zdp/NwkAddrRequest.cs
+++ b/src/Haus.Zigbee/Zdp/NwkAddrRequest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Buffers.Binary;
+using Haus.Zigbee.Models;
+
+namespace Haus.Zigbee.Zdp;
+
+public record NwkAddrRequest(byte TransactionSequenceNumber, IeeeAddress IeeeAddress);
+
+public record NwkAddrResponse(
+    byte TransactionSequenceNumber,
+    ZdoStatus Status,
+    IeeeAddress IeeeAddress,
+    ushort NetworkAddress
+);
+
+public static class NwkAddrResponseCodec
+{
+    private const int TransactionSequenceNumberOffset = 0;
+    private const int StatusOffset = 1;
+    private const int IeeeAddressOffset = 2;
+    private const int NetworkAddressOffset = 10;
+    private const int NetworkAddressLength = 2;
+
+    // This response comes straight off the wire, so a truncated payload must produce a null result
+    // here rather than throw -- see ActiveEndpointsResponseCodec.Decode for why an exception here
+    // would silently stop delivery to every other IndicationReceived subscriber. Trailing bytes past
+    // the fixed prefix belong to an Extended Response we never requested, so they are ignored.
+    public static NwkAddrResponse? Decode(ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length <= StatusOffset)
+            return null;
+
+        var transactionSequenceNumber = payload[TransactionSequenceNumberOffset];
+        var status = (ZdoStatus)payload[StatusOffset];
+        if (status != ZdoStatus.Success)
+            return new NwkAddrResponse(transactionSequenceNumber, status, default, NetworkAddress: 0);
+
+        if (payload.Length < NetworkAddressOffset + NetworkAddressLength)
+            return null;
+
+        var ieeeAddress = new IeeeAddress(BinaryPrimitives.ReadUInt64LittleEndian(payload[IeeeAddressOffset..]));
+        var networkAddress = BinaryPrimitives.ReadUInt16LittleEndian(payload[NetworkAddressOffset..]);
+        return new NwkAddrResponse(transactionSequenceNumber, status, ieeeAddress, networkAddress);
+    }
+}
+
+public static class NwkAddrRequestCodec
+{
+    private const int RequestLength = 11;
+    private const int TransactionSequenceNumberOffset = 0;
+    private const int IeeeAddressOffset = 1;
+    private const int RequestTypeOffset = 9;
+    private const int StartIndexOffset = 10;
+    private const byte SingleDeviceResponse = 0x00;
+    private const byte StartIndex = 0x00;
+
+    public static byte[] Encode(NwkAddrRequest request)
+    {
+        var bytes = new byte[RequestLength];
+        bytes[TransactionSequenceNumberOffset] = request.TransactionSequenceNumber;
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes.AsSpan(IeeeAddressOffset), request.IeeeAddress.Value);
+        bytes[RequestTypeOffset] = SingleDeviceResponse;
+        bytes[StartIndexOffset] = StartIndex;
+        return bytes;
+    }
+}

--- a/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
@@ -26,6 +26,10 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public ushort? NetworkAddressToReturn { get; set; }
     public List<IeeeAddress> ResolveNetworkAddressCalls { get; } = [];
 
+    // Lets a test hold ResolveNetworkAddressAsync open indefinitely, to prove a caller does not
+    // block waiting on it. Left null, resolution completes immediately with NetworkAddressToReturn.
+    public TaskCompletionSource<ushort?>? ResolveNetworkAddressGate { get; set; }
+
     public bool IsConnected { get; set; }
     public NetworkConfig? NetworkConfig { get; set; }
     public Exception? ConnectShouldThrow { get; set; }
@@ -61,7 +65,7 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public Task<ushort?> ResolveNetworkAddressAsync(IeeeAddress ieeeAddress, CancellationToken token)
     {
         ResolveNetworkAddressCalls.Add(ieeeAddress);
-        return Task.FromResult(NetworkAddressToReturn);
+        return ResolveNetworkAddressGate?.Task ?? Task.FromResult(NetworkAddressToReturn);
     }
 
     public Task SetPermitJoinAsync(bool enabled, CancellationToken token)

--- a/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Support/FakeZigbeeCoordinator.cs
@@ -21,6 +21,11 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public Queue<ApsDataConfirm> ConfirmSequence { get; } = new();
     public ZigbeeDeviceInfo? DeviceInfoToReturn { get; set; }
 
+    // Default null means "no resolution" -- the relay's stale-address fallback treats that as a
+    // timeout and drops the command, exactly like a device that never answered the broadcast.
+    public ushort? NetworkAddressToReturn { get; set; }
+    public List<IeeeAddress> ResolveNetworkAddressCalls { get; } = [];
+
     public bool IsConnected { get; set; }
     public NetworkConfig? NetworkConfig { get; set; }
     public Exception? ConnectShouldThrow { get; set; }
@@ -51,6 +56,12 @@ public class FakeZigbeeCoordinator : IZigbeeCoordinator
     public Task<ZigbeeDeviceInfo?> ReadDeviceInfoAsync(IeeeAddress ieeeAddress, CancellationToken token)
     {
         return Task.FromResult(DeviceInfoToReturn);
+    }
+
+    public Task<ushort?> ResolveNetworkAddressAsync(IeeeAddress ieeeAddress, CancellationToken token)
+    {
+        ResolveNetworkAddressCalls.Add(ieeeAddress);
+        return Task.FromResult(NetworkAddressToReturn);
     }
 
     public Task SetPermitJoinAsync(bool enabled, CancellationToken token)

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/DeviceBackfillServiceTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/DeviceBackfillServiceTests.cs
@@ -75,6 +75,43 @@ public class DeviceBackfillServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task BackfillAsync_ResolvesEachKnownDevicesNetworkAddressAndUsesTheResolvedAddress()
+    {
+        var address = new IeeeAddress(1);
+        _coordinator!.DevicesToReturn = [new ZigbeeDevice(address, 0x1234, [])];
+        _coordinator.DeviceInfoToReturn = new ZigbeeDeviceInfo("Philips", "929002335001");
+        _coordinator.NetworkAddressToReturn = 0x5678;
+        DeviceDiscoveredEvent? published = null;
+        await _mqttClient!.SubscribeToHausEventsAsync<DeviceDiscoveredEvent>(
+            DeviceDiscoveredEvent.Type,
+            e => published = e.Payload
+        );
+
+        await _service!.BackfillAsync(CancellationToken.None);
+
+        Assert.Equal([address], _coordinator.ResolveNetworkAddressCalls);
+        Eventually.Assert(() => Assert.Equal((ushort?)0x5678, published?.NetworkAddress));
+    }
+
+    [Fact]
+    public async Task BackfillAsync_ResolutionFindsNoAnswer_FallsBackToTheAlreadyKnownNetworkAddress()
+    {
+        var address = new IeeeAddress(1);
+        _coordinator!.DevicesToReturn = [new ZigbeeDevice(address, 0x1234, [])];
+        _coordinator.DeviceInfoToReturn = new ZigbeeDeviceInfo("Philips", "929002335001");
+        _coordinator.NetworkAddressToReturn = null;
+        DeviceDiscoveredEvent? published = null;
+        await _mqttClient!.SubscribeToHausEventsAsync<DeviceDiscoveredEvent>(
+            DeviceDiscoveredEvent.Type,
+            e => published = e.Payload
+        );
+
+        await _service!.BackfillAsync(CancellationToken.None);
+
+        Eventually.Assert(() => Assert.Equal((ushort?)0x1234, published?.NetworkAddress));
+    }
+
+    [Fact]
     public async Task BackfillAsync_DeviceInfoResolvesToUnknown_DoesNotPublish()
     {
         var address = new IeeeAddress(1);

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Haus.Core.Models.Common;
 using Haus.Core.Models.Devices;
 using Haus.Core.Models.Devices.Events;
 using Haus.Core.Models.Discovery;
@@ -139,6 +140,41 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
                 Assert.Equal(resolvedNetworkAddress, request.Destination.ShortAddress);
             }
         );
+    }
+
+    [Fact]
+    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddressButResolvable_PublishesDeviceDiscoveredCarryingOriginalDeviceTypeAndMetadata()
+    {
+        const ushort resolvedNetworkAddress = 0x1234;
+        _coordinator!.NetworkAddressToReturn = resolvedNetworkAddress;
+        var externalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1));
+        var metadata = new[] { new MetadataModel("model", "LED1836G9") };
+        var device = new DeviceModel
+        {
+            ExternalId = externalId,
+            DeviceType = DeviceType.Light,
+            Metadata = metadata,
+        };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+        DeviceDiscoveredEvent? published = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<DeviceDiscoveredEvent>(
+            DeviceDiscoveredEvent.Type,
+            e => published = e.Payload
+        );
+
+        await _relay!.HandleCommandAsync(message, CancellationToken.None);
+
+        Assert.True(_addressRegistry!.TryGetExternalId(resolvedNetworkAddress, out var registeredExternalId));
+        Assert.Equal(externalId, registeredExternalId);
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(externalId, published?.Id);
+            Assert.Equal(DeviceType.Light, published?.DeviceType);
+            Assert.Equal(resolvedNetworkAddress, published?.NetworkAddress);
+            Assert.Equal(metadata, published?.Metadata);
+        });
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
@@ -114,6 +114,34 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddressButResolvable_SendsCommandsUsingTheResolvedNetworkAddress()
+    {
+        const ushort resolvedNetworkAddress = 0x1234;
+        _coordinator!.NetworkAddressToReturn = resolvedNetworkAddress;
+        var device = new DeviceModel
+        {
+            ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
+            DeviceType = DeviceType.Light,
+        };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+
+        await _relay!.HandleCommandAsync(message, CancellationToken.None);
+
+        Assert.Equal([new IeeeAddress(1)], _coordinator.ResolveNetworkAddressCalls);
+        Assert.NotEmpty(_coordinator.SentCommands);
+        Assert.All(
+            _coordinator.SentCommands,
+            request =>
+            {
+                Assert.Equal(DeconzAddressMode.Nwk, request.Destination.Mode);
+                Assert.Equal(resolvedNetworkAddress, request.Destination.ShortAddress);
+            }
+        );
+    }
+
+    [Fact]
     public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddress_SendsNothing()
     {
         var device = new DeviceModel { ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)) };

--- a/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
+++ b/tests/Haus.Zigbee.Host.Tests/Zigbee/Services/ZigbeeOutboundRelayTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Haus.Core.Models.Common;
@@ -115,10 +116,11 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddressButResolvable_SendsCommandsUsingTheResolvedNetworkAddress()
+    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddress_DoesNotWaitOnResolutionBeforeReturning()
     {
-        const ushort resolvedNetworkAddress = 0x1234;
-        _coordinator!.NetworkAddressToReturn = resolvedNetworkAddress;
+        _coordinator!.ResolveNetworkAddressGate = new TaskCompletionSource<ushort?>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
         var device = new DeviceModel
         {
             ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
@@ -128,18 +130,65 @@ public class ZigbeeOutboundRelayTests : IAsyncLifetime
             .AsHausCommand()
             .ToMqttMessage("haus/commands");
 
+        var handleTask = _relay!.HandleCommandAsync(message, CancellationToken.None);
+        var completed = await Task.WhenAny(handleTask, Task.Delay(TimeSpan.FromSeconds(2)));
+
+        Assert.Same(handleTask, completed);
+    }
+
+    [Fact]
+    public async Task HandleCommandAsync_LightingCommandWithoutNetworkAddressButResolvable_DropsTheCommandAndResolvesTheAddressInTheBackgroundForNextTime()
+    {
+        const ushort resolvedNetworkAddress = 0x1234;
+        _coordinator!.NetworkAddressToReturn = resolvedNetworkAddress;
+        var externalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1));
+        var device = new DeviceModel { ExternalId = externalId, DeviceType = DeviceType.Light };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+        ZigbeeCommandDroppedEvent? dropped = null;
+        await _hausMqttClient!.SubscribeToHausEventsAsync<ZigbeeCommandDroppedEvent>(
+            ZigbeeCommandDroppedEvent.Type,
+            e => dropped = e.Payload
+        );
+
         await _relay!.HandleCommandAsync(message, CancellationToken.None);
 
-        Assert.Equal([new IeeeAddress(1)], _coordinator.ResolveNetworkAddressCalls);
-        Assert.NotEmpty(_coordinator.SentCommands);
-        Assert.All(
-            _coordinator.SentCommands,
-            request =>
-            {
-                Assert.Equal(DeconzAddressMode.Nwk, request.Destination.Mode);
-                Assert.Equal(resolvedNetworkAddress, request.Destination.ShortAddress);
-            }
+        Assert.Empty(_coordinator.SentCommands);
+        Eventually.Assert(() =>
+        {
+            Assert.Equal(externalId, dropped?.ExternalId);
+            Assert.Equal([new IeeeAddress(1)], _coordinator.ResolveNetworkAddressCalls);
+            Assert.True(_addressRegistry!.TryGetExternalId(resolvedNetworkAddress, out var registeredExternalId));
+            Assert.Equal(externalId, registeredExternalId);
+        });
+    }
+
+    [Fact]
+    public async Task HandleCommandAsync_RepeatedLightingCommandsWithoutNetworkAddressForTheSameDevice_OnlyResolvesOnceWhileAResolutionIsPending()
+    {
+        _coordinator!.ResolveNetworkAddressGate = new TaskCompletionSource<ushort?>(
+            TaskCreationOptions.RunContinuationsAsynchronously
         );
+        var device = new DeviceModel
+        {
+            ExternalId = ExternalIdConverter.ToExternalId(new IeeeAddress(1)),
+            DeviceType = DeviceType.Light,
+        };
+        var message = new DeviceLightingChangedEvent(device, new LightingModel(LightingState.On))
+            .AsHausCommand()
+            .ToMqttMessage("haus/commands");
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await Task.WhenAny(
+            Task.WhenAll(
+                _relay!.HandleCommandAsync(message, CancellationToken.None),
+                _relay.HandleCommandAsync(message, CancellationToken.None)
+            ),
+            Task.Delay(Timeout.Infinite, timeout.Token)
+        );
+
+        Eventually.Assert(() => Assert.Single(_coordinator!.ResolveNetworkAddressCalls));
     }
 
     [Fact]

--- a/tests/Haus.Zigbee.Tests/Coordinator/KnownDeviceTableTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/KnownDeviceTableTests.cs
@@ -76,6 +76,34 @@ public class KnownDeviceTableTests
         Assert.False(found);
     }
 
+    [Fact]
+    public void WhenNetworkAddressIsUpdatedForAnAlreadyKnownDeviceThenItsEndpointsArePreserved()
+    {
+        var table = new KnownDeviceTable();
+        var endpoint = new ZigbeeEndpoint(0x01, 0x0104, 0x0100, new ushort[] { 0x0000 }, Array.Empty<ushort>());
+        var ieeeAddress = new IeeeAddress(0x00124b0001234567);
+        table.AddOrUpdate(new ZigbeeDevice(ieeeAddress, NetworkAddress: 0x1234, new[] { endpoint }));
+
+        table.UpdateNetworkAddress(ieeeAddress, networkAddress: 0x9999);
+
+        table.TryGet(ieeeAddress, out var updated);
+        Assert.Equal(0x9999, updated!.NetworkAddress);
+        Assert.Equal(new[] { endpoint }, updated.Endpoints);
+    }
+
+    [Fact]
+    public void WhenNetworkAddressIsUpdatedForAnUnknownDeviceThenItIsAddedWithNoEndpoints()
+    {
+        var table = new KnownDeviceTable();
+        var ieeeAddress = new IeeeAddress(0x00124b0001234567);
+
+        table.UpdateNetworkAddress(ieeeAddress, networkAddress: 0x9999);
+
+        table.TryGet(ieeeAddress, out var added);
+        Assert.Equal(0x9999, added!.NetworkAddress);
+        Assert.Empty(added.Endpoints);
+    }
+
     private static ZigbeeDevice DeviceWith(ulong ieeeAddress, ushort networkAddress)
     {
         return new ZigbeeDevice(new IeeeAddress(ieeeAddress), networkAddress, Array.Empty<ZigbeeEndpoint>());

--- a/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
@@ -44,6 +44,23 @@ public class NetworkAddressResolverTests
         Assert.Equal(0x1a2b, known.NetworkAddress);
     }
 
+    [Fact]
+    public async Task WhenTheIeeeAddressIsAlreadyKnownWithEndpointsThenResolvingUpdatesItsNetworkAddressWhilePreservingThoseEndpoints()
+    {
+        var ieee = new IeeeAddress(0x00124b0001aabbcc);
+        var endpoint = new ZigbeeEndpoint(0x01, 0x0104, 0x0100, new ushort[] { 0x0000 }, Array.Empty<ushort>());
+        _knownDeviceTable.AddOrUpdate(new ZigbeeDevice(ieee, NetworkAddress: 0x0001, new[] { endpoint }));
+        _dongle.ReleaseAfterSend(sendIndex: 0, NwkAddrResponse(ieee, networkAddress: 0x1a2b, tsn: 0x00));
+
+        var resolved = await RunToCompletion(_resolver.ResolveAsync(ieee, CancellationToken.None));
+
+        Assert.Equal((ushort?)0x1a2b, resolved);
+        var known = Assert.Single(_knownDeviceTable.GetDevices());
+        Assert.Equal(0x1a2b, known.NetworkAddress);
+        var preserved = Assert.Single(known.Endpoints);
+        Assert.Equal(0x01, preserved.EndpointId);
+    }
+
     private async Task<T> RunToCompletion<T>(Task<T> task)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
@@ -61,6 +61,45 @@ public class NetworkAddressResolverTests
         Assert.Equal(0x01, preserved.EndpointId);
     }
 
+    [Fact]
+    public async Task WhenNoDeviceAnswersTheBroadcastRequestThenResolvingReturnsNullWithoutRecordingAnything()
+    {
+        using var resolver = new NetworkAddressResolver(
+            _pollLoop,
+            _sender,
+            _knownDeviceTable,
+            responseTimeout: TimeSpan.FromMilliseconds(50)
+        );
+        var ieee = new IeeeAddress(0x00124b0001aabbcc);
+
+        var resolved = await RunToCompletion(resolver.ResolveAsync(ieee, CancellationToken.None));
+
+        Assert.Null(resolved);
+        Assert.Empty(_knownDeviceTable.GetDevices());
+    }
+
+    [Fact]
+    public async Task WhenAnIndicationOnAnUnrelatedClusterArrivesFirstThenItIsIgnoredAndTheResolverKeepsWaitingForItsResponse()
+    {
+        var ieee = new IeeeAddress(0x00124b0001aabbcc);
+        // Same transaction sequence number as the request, but a different cluster -- proves the
+        // resolver filters on cluster and does not complete on this indication.
+        _dongle.InjectIndication(
+            new IndicationBody(
+                SourceNwk: 0x1a2b,
+                SourceEndpoint: 0x00,
+                ZdpProfile,
+                ActiveEndpointsResponseCluster,
+                Asdu: new byte[] { 0x00, 0x00, 0x00 }
+            )
+        );
+        _dongle.ReleaseAfterSend(sendIndex: 0, NwkAddrResponse(ieee, networkAddress: 0x1a2b, tsn: 0x00));
+
+        var resolved = await RunToCompletion(_resolver.ResolveAsync(ieee, CancellationToken.None));
+
+        Assert.Equal((ushort?)0x1a2b, resolved);
+    }
+
     private async Task<T> RunToCompletion<T>(Task<T> task)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
@@ -79,6 +79,19 @@ public class NetworkAddressResolverTests
     }
 
     [Fact]
+    public async Task WhenTheResponseIeeeAddressDoesNotMatchTheRequestedAddressThenResolvingReturnsNullWithoutRecordingAnything()
+    {
+        var requested = new IeeeAddress(0x00124b0001aabbcc);
+        var responder = new IeeeAddress(0x00124b0009999999);
+        _dongle.ReleaseAfterSend(sendIndex: 0, NwkAddrResponse(responder, networkAddress: 0x1a2b, tsn: 0x00));
+
+        var resolved = await RunToCompletion(_resolver.ResolveAsync(requested, CancellationToken.None));
+
+        Assert.Null(resolved);
+        Assert.Empty(_knownDeviceTable.GetDevices());
+    }
+
+    [Fact]
     public async Task WhenAnIndicationOnAnUnrelatedClusterArrivesFirstThenItIsIgnoredAndTheResolverKeepsWaitingForItsResponse()
     {
         var ieee = new IeeeAddress(0x00124b0001aabbcc);

--- a/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/NetworkAddressResolverTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Haus.Zigbee.Connection;
+using Haus.Zigbee.Coordinator;
+using Haus.Zigbee.Models;
+using Haus.Zigbee.Simulator;
+using Haus.Zigbee.Zdp;
+using Xunit;
+
+namespace Haus.Zigbee.Tests.Coordinator;
+
+public class NetworkAddressResolverTests
+{
+    private const ushort ZdpProfile = 0x0000;
+    private const ushort NwkAddrResponseCluster = 0x8000;
+    private const ushort ActiveEndpointsResponseCluster = 0x8005;
+
+    private readonly FakeDeconzDongle _dongle = new();
+    private readonly ApsPollLoop _pollLoop;
+    private readonly ApsSender _sender;
+    private readonly KnownDeviceTable _knownDeviceTable = new();
+    private readonly NetworkAddressResolver _resolver;
+
+    public NetworkAddressResolverTests()
+    {
+        _pollLoop = new ApsPollLoop(new DeconzChannel(_dongle.PollTransport));
+        _sender = new ApsSender(_pollLoop, new DeconzChannel(_dongle.SendTransport));
+        _resolver = new NetworkAddressResolver(_pollLoop, _sender, _knownDeviceTable);
+    }
+
+    [Fact]
+    public async Task WhenAResponseArrivesForTheBroadcastRequestThenItResolvesTheNetworkAddressAndRecordsTheDeviceInTheKnownDeviceTable()
+    {
+        var ieee = new IeeeAddress(0x00124b0001aabbcc);
+        _dongle.ReleaseAfterSend(sendIndex: 0, NwkAddrResponse(ieee, networkAddress: 0x1a2b, tsn: 0x00));
+
+        var resolved = await RunToCompletion(_resolver.ResolveAsync(ieee, CancellationToken.None));
+
+        Assert.Equal((ushort?)0x1a2b, resolved);
+        var known = Assert.Single(_knownDeviceTable.GetDevices());
+        Assert.Equal(ieee, known.IeeeAddress);
+        Assert.Equal(0x1a2b, known.NetworkAddress);
+    }
+
+    private async Task<T> RunToCompletion<T>(Task<T> task)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!task.IsCompleted && !timeout.IsCancellationRequested)
+        {
+            await _pollLoop.PollOnceAsync(CancellationToken.None);
+            if (!task.IsCompleted)
+                await Task.Delay(1);
+        }
+
+        Assert.True(task.IsCompleted, "did not complete within the timeout");
+        return await task;
+    }
+
+    private static IndicationBody NwkAddrResponse(
+        IeeeAddress ieee,
+        ushort networkAddress,
+        byte tsn,
+        ZdoStatus status = ZdoStatus.Success
+    )
+    {
+        var asdu = new List<byte> { tsn, (byte)status };
+        AddUInt64(asdu, ieee.Value);
+        AddUInt16(asdu, networkAddress);
+        return new IndicationBody(
+            networkAddress,
+            SourceEndpoint: 0x00,
+            ZdpProfile,
+            NwkAddrResponseCluster,
+            asdu.ToArray()
+        );
+    }
+
+    private static void AddUInt16(List<byte> bytes, ushort value)
+    {
+        bytes.Add((byte)(value & 0xff));
+        bytes.Add((byte)(value >> 8));
+    }
+
+    private static void AddUInt64(List<byte> bytes, ulong value)
+    {
+        for (var shift = 0; shift < 64; shift += 8)
+            bytes.Add((byte)((value >> shift) & 0xff));
+    }
+}

--- a/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
+++ b/tests/Haus.Zigbee.Tests/Coordinator/ZigbeeCoordinatorTests.cs
@@ -361,6 +361,45 @@ public class ZigbeeCoordinatorTests
         Assert.Equal(string.Empty, info.ModelIdentifier);
     }
 
+    [Fact]
+    public async Task WhenABroadcastNwkAddressRequestIsAnsweredThenResolveNetworkAddressReturnsItAndRecordsTheDevice()
+    {
+        SetNetworkParameters();
+        using var coordinator = new ZigbeeCoordinator(_dongle);
+        await coordinator.ConnectAsync(CancellationToken.None);
+        _dongle.ReleaseAfterApsRequest(
+            apsRequestIndex: 0,
+            NwkAddrResponseIndication(networkAddress: 0x1a2b, ieee: 0x00124b0001aabbcc)
+        );
+
+        var resolved = await WaitFor(
+            coordinator.ResolveNetworkAddressAsync(new IeeeAddress(0x00124b0001aabbcc), CancellationToken.None)
+        );
+
+        Assert.Equal((ushort?)0x1a2b, resolved);
+        var devices = await coordinator.GetDevicesAsync(CancellationToken.None);
+        var device = Assert.Single(devices);
+        Assert.Equal(new IeeeAddress(0x00124b0001aabbcc), device.IeeeAddress);
+        Assert.Equal((ushort)0x1a2b, device.NetworkAddress);
+    }
+
+    private static IndicationBody NwkAddrResponseIndication(ushort networkAddress, ulong ieee)
+    {
+        const ushort zdpProfile = 0x0000;
+        const ushort nwkAddrResponseCluster = 0x8000;
+        const byte successStatus = 0x00;
+        var asdu = new List<byte> { 0x00, successStatus };
+        AddUInt64(asdu, ieee);
+        AddUInt16(asdu, networkAddress);
+        return new IndicationBody(
+            networkAddress,
+            SourceEndpoint: 0x00,
+            zdpProfile,
+            nwkAddrResponseCluster,
+            asdu.ToArray()
+        );
+    }
+
     private void DriveJoinWithNoEndpoints(ushort networkAddress, ulong ieee)
     {
         _dongle.InjectIndication(AnnounceIndication(networkAddress, ieee));

--- a/tests/Haus.Zigbee.Tests/Zdp/NwkAddrRequestTests.cs
+++ b/tests/Haus.Zigbee.Tests/Zdp/NwkAddrRequestTests.cs
@@ -1,0 +1,109 @@
+using Haus.Zigbee.Models;
+using Haus.Zigbee.Zdp;
+using Xunit;
+
+namespace Haus.Zigbee.Tests.Zdp;
+
+public class NwkAddrRequestTests
+{
+    [Fact]
+    public void WhenEncodingRequestThenProducesTransactionSequenceNumberLittleEndianIeeeAddressSingleResponseTypeAndZeroStartIndex()
+    {
+        var request = new NwkAddrRequest(
+            TransactionSequenceNumber: 0x42,
+            IeeeAddress: new IeeeAddress(0x00124b0001aabbcc)
+        );
+
+        var bytes = NwkAddrRequestCodec.Encode(request);
+
+        Assert.Equal(new byte[] { 0x42, 0xcc, 0xbb, 0xaa, 0x01, 0x00, 0x4b, 0x12, 0x00, 0x00, 0x00 }, bytes);
+    }
+
+    [Fact]
+    public void WhenDecodingSuccessfulResponseThenRecoversTransactionSequenceNumberIeeeAddressAndLittleEndianNetworkAddress()
+    {
+        var payload = new byte[] { 0x42, 0x00, 0xcc, 0xbb, 0xaa, 0x01, 0x00, 0x4b, 0x12, 0x00, 0x2b, 0x1a };
+
+        var response = NwkAddrResponseCodec.Decode(payload);
+
+        Assert.NotNull(response);
+        Assert.Equal(0x42, response.TransactionSequenceNumber);
+        Assert.Equal(ZdoStatus.Success, response.Status);
+        Assert.Equal(new IeeeAddress(0x00124b0001aabbcc), response.IeeeAddress);
+        Assert.Equal(0x1a2b, response.NetworkAddress);
+    }
+
+    [Fact]
+    public void WhenDecodingSuccessfulResponseWithTrailingExtendedResponseBytesThenIgnoresThemAndRecoversTheFixedPrefix()
+    {
+        var payload = new byte[]
+        {
+            0x42,
+            0x00,
+            0xcc,
+            0xbb,
+            0xaa,
+            0x01,
+            0x00,
+            0x4b,
+            0x12,
+            0x00,
+            0x2b,
+            0x1a,
+            0x02,
+            0x00,
+            0x34,
+            0x12,
+        };
+
+        var response = NwkAddrResponseCodec.Decode(payload);
+
+        Assert.NotNull(response);
+        Assert.Equal(0x1a2b, response.NetworkAddress);
+    }
+
+    [Fact]
+    public void WhenDecodingNonSuccessResponseThenRecoversStatusWithoutReadingFurtherBytesOrThrowing()
+    {
+        var payload = new byte[] { 0x42, (byte)ZdoStatus.DeviceNotFound };
+
+        var response = NwkAddrResponseCodec.Decode(payload);
+
+        Assert.NotNull(response);
+        Assert.Equal(0x42, response.TransactionSequenceNumber);
+        Assert.Equal(ZdoStatus.DeviceNotFound, response.Status);
+    }
+
+    private static readonly byte[] ValidSuccessPayload =
+    [
+        0x42,
+        0x00,
+        0xcc,
+        0xbb,
+        0xaa,
+        0x01,
+        0x00,
+        0x4b,
+        0x12,
+        0x00,
+        0x2b,
+        0x1a,
+    ];
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(10)]
+    [InlineData(11)]
+    public void WhenDecodingASuccessResponseTruncatedBeforeItsFieldsAreCompleteThenReturnsNullInsteadOfThrowing(
+        int length
+    )
+    {
+        var payload = ValidSuccessPayload[..length];
+
+        var response = NwkAddrResponseCodec.Decode(payload);
+
+        Assert.Null(response);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #9. Lighting commands to a previously-paired device were silently dropped after every `Haus.Zigbee.Host` restart, because `ZigbeeCoordinator.KnownDeviceTable` starts empty and is only populated by a live ZDP Device Announce — a device that hasn't re-announced since restart has no known `NetworkAddress`.

**Root cause fix:** when a device's `NetworkAddress` is unknown, broadcast a ZDP `NWK_addr_req` (built on deCONZ's existing APS_DATA_REQUEST/APS_DATA_INDICATION passthrough — confirmed against the deCONZ serial protocol spec that there's no bulk device-table read on this hardware), bounded by a 30s timeout. A successful response is verified against the IEEE address that was actually asked about before being trusted, then persisted via `DeviceDiscoveredEvent` so future commands don't need to re-resolve. A timeout keeps the existing visible-drop behavior (`ZigbeeCommandDroppedEvent`, from #66).

**Not blocking the shared MQTT pump:** the resolution never blocks `ZigbeeOutboundRelay.HandleLightingAsync` inline — it runs inside `HausMqttClient`'s single serialized message handler, so an inline 30s wait would have blocked every other incoming MQTT command. The current command still drops immediately; resolution runs as a detached, per-device-deduped background task so only the *next* command for that device benefits.

**Startup sweep (added scope):** `DeviceBackfillService` now also resolves each already-known device's `NetworkAddress` proactively at connect, reusing the same on-demand resolver, so a device that changed short address between sessions gets it re-populated before ever being needed for a command — not just reactively on a dropped command.

Two fresh-eyes review passes ran against this branch; both blocking findings from the first pass (MQTT-pump blocking, IEEE-response spoofing) were fixed, and a RequestId-collision question was investigated and documented as a pre-existing, out-of-scope risk. A second pass found one more real gap — a lost-update race where `NetworkAddressResolver`'s non-atomic read-then-write of `KnownDeviceTable` could clobber a concurrently-completing device interview's freshly discovered endpoints — closed by making the update atomic (`KnownDeviceTable.UpdateNetworkAddress`). Full history and rationale are in `docs/craft/design/2026-08-24-nwk-addr-resolution-fallback.md`.

## Test plan
- [x] `Haus.Zigbee.Tests`: 251/251 passing
- [x] `Haus.Zigbee.Host.Tests`: 91/91 passing
- [x] `Haus.Core.Tests`: 266/266 passing (unaffected, regression check)
- [x] All new behavior driven by strict TDD against real fakes (`FakeDeconzDongle`/`FakeSerialTransport`, `FakeZigbeeCoordinator`) — no mocking of owned in-process code
- [x] No production/real database touched — unit/fake-transport suites only