### PR TITLE
chore(deps): update outdated dependencies

### DIFF
--- a/src/Haus.Site.Host/Haus.Site.Host.csproj
+++ b/src/Haus.Site.Host/Haus.Site.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <ItemGroup>
     <PackageReference Include="Humanizer" Version="3.0.10" />
-    <PackageReference Include="MudBlazor" Version="9.8.0" />
+    <PackageReference Include="MudBlazor" Version="9.9.0" />
     <PackageReference
       Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication"
       Version="$(MicrosoftPackageVersion)"

--- a/src/Haus.Utilities/Haus.Utilities.csproj
+++ b/src/Haus.Utilities/Haus.Utilities.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
   </ItemGroup>

--- a/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
+++ b/tests/Haus.Acceptance.Tests/Haus.Acceptance.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.62.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">


### PR DESCRIPTION
## Summary

Routine dependency audit and update. Scope covered: .NET SDK, all NuGet packages across `src/` and `tests/`, local dotnet tools (`.config/dotnet-tools.json`), and GitHub Actions pins.

Most of the repo was already current:
- **.NET SDK** (`global.json`): already pinned to `10.0.400`, the latest stable SDK as of this update — no change needed.
- **Local dotnet tools** (reportgenerator, dotnet-ef, csharpier, husky, dotnet-outdated-tool, powershell): all already at latest stable — no change needed.
- **GitHub Actions**: all `uses:` pins (`actions/checkout@v7`, `actions/upload-artifact@v7`, `actions/setup-dotnet@v6`, `taiki-e/install-action@v2`, `softprops/action-gh-release@v3`) already track the latest stable major — no change needed.
- No `Directory.Packages.props` (no central package management) and no `package.json` in this repo.
- `dotnet list package --vulnerable` reported no known CVEs anywhere in the solution.

Three NuGet packages were outdated and bumped, one per commit:

| Package | From | To | Project |
|---|---|---|---|
| `MudBlazor` | 9.8.0 | 9.9.0 | `Haus.Site.Host` |
| `HtmlAgilityPack` | 1.12.4 | 1.13.0 | `Haus.Utilities` |
| `NUnit3TestAdapter` | 6.2.0 | 6.3.0 | `Haus.Acceptance.Tests` |

All three are routine minor/patch bumps with no breaking changes per upstream release notes — no source changes were required.

## Note on acceptance-suite flakiness observed during verification

While verifying the `NUnit3TestAdapter` bump, the acceptance suite showed intermittent failures (1-2 of 7 tests, a different UI/SignalR-timing test each run). I reverted the adapter to 6.2.0 and reproduced the same flakiness, confirming it predates and is unrelated to this bump — most likely environmental (this was run in a sandbox with other long-running containers and active swap pressure). Not fixed here, since it's out of scope for a dependency bump; worth a look if it recurs in CI.

## Test plan

Every commit was gated individually with `dotnet build`, `make test-unit` (971 tests), and `make test-acceptance` (7 tests) before moving to the next:
- [x] `dotnet build` — green after each commit
- [x] `make test-unit` — 971/971 passing after each commit
- [x] `make test-acceptance` — 7/7 passing after the MudBlazor and HtmlAgilityPack commits; intermittently 5-6/7 passing after the NUnit3TestAdapter commit (see flakiness note above — reproduced independent of the bump)
- [x] `dotnet csharpier check` — clean after each commit
- [x] `dotnet list package --vulnerable` — no CVEs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3eTEVQpHAW746PgAiUyS2